### PR TITLE
Fix Rust version replacement

### DIFF
--- a/metapkg/packages/rust.py
+++ b/metapkg/packages/rust.py
@@ -43,7 +43,9 @@ class BundledRustPackage(base.BundledPackage):
         else:
             target = ''
         return textwrap.dedent(f'''\
-            sed -i -e 's/version =.*/version = "{self.version.text}"/' \\
+            sed -i -e '/\[package\]/,/\[.*\]/{
+                    s/^version\s*=.*/version = "{self.version.text}"/;
+                }' \\
                 "{src}/Cargo.toml"
             {cargo} install {target} \\
                 --root "{installdest}" \\


### PR DESCRIPTION
`version =` can be not just in the `[package]` section, but also in dependencies (even as a separate line, because dependencies can be written as section instead of inline table).

Example failure:
https://github.com/edgedb/edgedb-cli/runs/3008481836?check_suite_focus=true#step:3:343