### PR TITLE
Use gsed on macOS

### DIFF
--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -91,8 +91,11 @@ class Build(base.Command):
 
         target: targets.Target
         if generic:
-            if platform.system() == "Linux":
+            current_system = platform.system()
+            if current_system == "Linux":
                 target = targets.generic.GenericLinuxTarget()
+            elif current_system == "Darwin":
+                target = targets.macos.GenericMacOSTarget()
             else:
                 target = targets.generic.GenericTarget()
         else:

--- a/metapkg/packages/rust.py
+++ b/metapkg/packages/rust.py
@@ -46,6 +46,7 @@ class BundledRustPackage(base.BundledPackage):
 
     def get_build_install_script(self, build: targets.Build) -> str:
         cargo = build.sh_get_command("cargo")
+        sed = build.sh_get_command("sed")
         installdest = build.get_temp_dir(self, relative_to="pkgbuild")
         src = build.get_source_dir(self, relative_to="pkgbuild")
         bindir = build.get_install_path("systembin").relative_to("/")
@@ -58,7 +59,7 @@ class BundledRustPackage(base.BundledPackage):
             target = ""
         return textwrap.dedent(
             f"""\
-            sed -i -e '/\\[package\\]/,/\\[.*\\]/{{
+            {sed} -i -e '/\\[package\\]/,/\\[.*\\]/{{
                     s/^version\\s*=.*/version = "{self.version.text}"/;
                 }}' \\
                 "{src}/Cargo.toml"

--- a/metapkg/targets/generic/__init__.py
+++ b/metapkg/targets/generic/__init__.py
@@ -4,16 +4,20 @@ from typing import *
 import pathlib
 
 from metapkg import packages as mpkg
+from metapkg import tools
 from metapkg.packages import repository
 from metapkg.targets import base as targets
 from metapkg.targets.package import SystemPackage
 
-from .build import Build as Build
+from . import build as genbuild
 
 if TYPE_CHECKING:
     from cleo.io import io as cleo_io
     from poetry.core.packages import dependency as poetry_dep
     from poetry.core.packages import package as poetry_pkg
+
+
+Build = genbuild.Build
 
 
 PACKAGE_WHITELIST = [
@@ -111,7 +115,7 @@ class GenericTarget(targets.FHSTarget):
         subdist: str | None,
         extra_opt: bool,
     ) -> None:
-        return Build(
+        return genbuild.Build(
             self,
             io=io,
             root_pkg=root_pkg,

--- a/metapkg/targets/generic/build.py
+++ b/metapkg/targets/generic/build.py
@@ -36,6 +36,7 @@ class Build(targets.Build):
         self._system_tools["patch"] = "patch"
         self._system_tools["useradd"] = "useradd"
         self._system_tools["groupadd"] = "groupadd"
+        self._system_tools["sed"] = "sed"
 
         self._artifactroot = pathlib.Path("_artifacts")
         self._buildroot = self._artifactroot / "build"
@@ -426,3 +427,14 @@ class Build(targets.Build):
                             an / pathlib.Path(file).relative_to(image_root)
                         ),
                     )
+
+
+class GenericMacOSBuild(Build):
+    def prepare(self) -> None:
+        super().prepare()
+        self._system_tools["bash"] = "/usr/local/bin/bash"
+        self._system_tools["make"] = (
+            "env -u MAKELEVEL /usr/local/bin/gmake "
+            f"-j{os.cpu_count()} SHELL=/usr/local/bin/bash"
+        )
+        self._system_tools["sed"] = "/usr/local/bin/gsed"

--- a/metapkg/targets/macos/build.py
+++ b/metapkg/targets/macos/build.py
@@ -10,7 +10,7 @@ from metapkg.targets import generic
 from metapkg import tools
 
 
-class Build(generic.Build):
+class GenericBuild(generic.Build):
     def prepare(self) -> None:
         super().prepare()
         self._system_tools["bash"] = "/usr/local/bin/bash"
@@ -18,7 +18,10 @@ class Build(generic.Build):
             "env -u MAKELEVEL /usr/local/bin/gmake "
             f"-j{os.cpu_count()} SHELL=/usr/local/bin/bash"
         )
+        self._system_tools["sed"] = "/usr/local/bin/gsed"
 
+
+class NativePackageBuild(GenericBuild):
     def _build(self) -> None:
         super()._build()
         self._build_installer()


### PR DESCRIPTION
We cannot use the MacOSTarget because some build like the CLI is using the generic target.

[Sample build here](https://github.com/edgedb/edgedb-cli/runs/3283724416?check_suite_focus=true).