### PR TITLE
Revert "Make git checkout cache disablement opt-in"

### DIFF
--- a/metapkg/packages/sources.py
+++ b/metapkg/packages/sources.py
@@ -337,7 +337,6 @@ class GitSource(BaseSource):
             self.url,
             exclude_submodules=self.exclude_submodules,
             clone_depth=self.clone_depth,
-            clean_checkout=os.environ.get("METAPKG_GIT_CACHE") == "disabled",
             ref=self.ref,
         )
 

--- a/metapkg/tools/git.py
+++ b/metapkg/tools/git.py
@@ -57,13 +57,12 @@ def update_repo(
     *,
     exclude_submodules: frozenset[str] | None = None,
     clone_depth: int = 0,
-    clean_checkout: bool = False,
     ref: str | None = None,
 ) -> pathlib.Path:
     if ref == "HEAD":
         ref = None
 
-    GitBackend.clone(repo_url, revision=ref, clean=clean_checkout)
+    GitBackend.clone(repo_url, revision=ref, clean=True)
     repo_dir = repodir(repo_url)
     repo = Git(repo_dir)
     args: tuple[str | pathlib.Path, ...]


### PR DESCRIPTION
This reverts commit f85b3200224a764d46cf27c28ab8a4f14a967e0e.

Always clean before doing checkouts, since we think the cached
directories are probably the root of the "has no attribute `tags`"
build failures.