### PR TITLE
Re-export `packaging.utils.canonicalize_name`

### DIFF
--- a/metapkg/packages/__init__.py
+++ b/metapkg/packages/__init__.py
@@ -8,6 +8,7 @@ from .base import (
     BundledCMesonPackage,
     PackageFileLayout,
     MetaPackage,
+    canonicalize_name,
     pep440_to_semver,
     semver_pre_tag,
 )
@@ -30,6 +31,7 @@ __all__ = (
     "BundledPythonPackage",
     "BundledRustPackage",
     "BundledAdHocRustPackage",
+    "canonicalize_name",
     "pep440_to_semver",
     "semver_pre_tag",
 )

--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -49,6 +49,7 @@ if TYPE_CHECKING:
 
 get_build_requirements = repository.get_build_requirements
 set_build_requirements = repository.set_build_requirements
+canonicalize_name = packaging.utils.canonicalize_name
 
 
 class DummyPackage(poetry_pkg.Package):


### PR DESCRIPTION
This is needed to fix typing on package declarations and to avoid having
to import `packaging.utils` everywhere.
