### PR TITLE
Fix handling of dependencies enabled by target capabilities

### DIFF
--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -189,6 +189,8 @@ class Build(base.Command):
         sorter = graphlib.TopologicalSorter(graph)
         packages = [pkg_map[pn] for pn in sorter.static_order()]
 
+        af_repo.bundle_repo.remove_package(root)
+
         # Build a separate package list for build deps.
         build_root = project_package.ProjectPackage("__build_root__", "1")
         build_root.python_versions = (

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -169,10 +169,10 @@ class Provider(poetry_provider.Provider):
         pkg = super().complete_package(package)
 
         for dep in itertools.chain.from_iterable(chain):
-            if not dep.is_activated() and dep.in_extras:
-                if not ({str(e) for e in dep.in_extras} - self._active_extras):
-                    dep.activate()
-                    pkg.package.add_dependency(dep)
+            dep_in_extras = {str(e) for e in dep.in_extras}
+            if not (dep_in_extras - self._active_extras):
+                dep.activate()
+                pkg.package.add_dependency(dep)
 
         return pkg
 


### PR DESCRIPTION
Broken by #25, because the second dependency resolution run would
incorrectly skip dependencies activated in a previous run.
