### PR TITLE
Stop invoking `setup.py` directly to make sdist's

### DIFF
--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -626,9 +626,9 @@ class BundledPackage(BasePackage):
 
         if reqs:
             if poetry_depgroup.MAIN_GROUP not in self._dependency_groups:
-                self._dependency_groups[
-                    poetry_depgroup.MAIN_GROUP
-                ] = poetry_depgroup.DependencyGroup(poetry_depgroup.MAIN_GROUP)
+                self._dependency_groups[poetry_depgroup.MAIN_GROUP] = (
+                    poetry_depgroup.DependencyGroup(poetry_depgroup.MAIN_GROUP)
+                )
 
             main_group = self._dependency_groups[poetry_depgroup.MAIN_GROUP]
             for req in reqs:
@@ -711,20 +711,17 @@ class BundledPackage(BasePackage):
     @overload
     def read_support_files(
         self, build: targets.Build, file_glob: str, binary: Literal[False]
-    ) -> dict[str, str]:
-        ...
+    ) -> dict[str, str]: ...
 
     @overload
     def read_support_files(
         self, build: targets.Build, file_glob: str
-    ) -> dict[str, str]:
-        ...
+    ) -> dict[str, str]: ...
 
     @overload
     def read_support_files(
         self, build: targets.Build, file_glob: str, binary: Literal[True]
-    ) -> dict[str, bytes]:
-        ...
+    ) -> dict[str, bytes]: ...
 
     def read_support_files(
         self, build: targets.Build, file_glob: str, binary: bool = False
@@ -1075,9 +1072,9 @@ class BundledCPackage(BuildSystemMakePackage):
             build.sh_append_flags(configure_flags, f"LDFLAGS", ldflags)
 
         elif build.is_stdlib(pkg):
-            configure_flags[
-                f"{var_prefix}_CFLAGS"
-            ] = f"-D_{var_prefix}_IS_SYSLIB"
+            configure_flags[f"{var_prefix}_CFLAGS"] = (
+                f"-D_{var_prefix}_IS_SYSLIB"
+            )
             std_ldflags = []
             for shlib in pkg.get_shlibs(build):
                 std_ldflags.append(f"-l{shlib}")

--- a/metapkg/packages/sources.py
+++ b/metapkg/packages/sources.py
@@ -431,9 +431,10 @@ class GitSource(BaseSource):
         target_tarball: pathlib.Path,
     ) -> None:
         if platform.system() != "Linux":
-            with tarfile.open(source_tarball) as modf, tarfile.open(
-                target_tarball, "a"
-            ) as tf:
+            with (
+                tarfile.open(source_tarball) as modf,
+                tarfile.open(target_tarball, "a") as tf,
+            ):
                 for m in modf.getmembers():
                     if m.issym():
                         # Skip broken symlinks.

--- a/metapkg/targets/base.py
+++ b/metapkg/targets/base.py
@@ -1240,6 +1240,14 @@ class Build:
                     io=self._io,
                 )
 
+    def get_tarball(
+        self,
+        pkg: mpkg_base.BasePackage,
+        *,
+        relative_to: Location,
+    ) -> pathlib.Path:
+        return self.get_dir(self._tarballs[pkg], relative_to=relative_to)
+
     def prepare_patches(self) -> None:
         patches_dir = self.get_patches_root(relative_to="fsroot")
 

--- a/metapkg/targets/macos/build.py
+++ b/metapkg/targets/macos/build.py
@@ -23,9 +23,9 @@ class MacOSBuild(generic.Build):
         else:
             dash_j = f"-j{self._jobs}"
         gmake = self._find_tool("gmake")
-        self._system_tools[
-            "make"
-        ] = f"env -u MAKELEVEL {gmake} {dash_j} SHELL={bash}"
+        self._system_tools["make"] = (
+            f"env -u MAKELEVEL {gmake} {dash_j} SHELL={bash}"
+        )
         self._system_tools["sed"] = self._find_tool("gsed")
         self._system_tools["tar"] = self._find_tool("gtar")
 


### PR DESCRIPTION
Calling `setup.py` is deprecated and wouldn't work if it's not actually
there.  Luckily we don't actually _need_ to build a new sdist as we
should already have it downloaded from PyPI, so just use the source
tarball directly.
