### PR TITLE
Pass link flags to Rust more consistently

### DIFF
--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -338,7 +338,7 @@ class BundledPackage(BasePackage):
                     if "version" not in extras:
                         extras["version"] = version
                 else:
-                    extras = {"version": version}
+                    extras = af_sources.SourceExtraDecl({"version": version})
 
                 if "vcs_version" not in extras:
                     extras["vcs_version"] = cls.to_vcs_version(
@@ -1037,29 +1037,28 @@ class BundledCPackage(BuildSystemMakePackage):
             )
 
             if var_prefix:
-                build.sh_append_flags(
+                build.sh_append_quoted_flags(
                     configure_flags,
                     f"{var_prefix}_CFLAGS",
-                    f"-I{rel_path}/include/",
+                    [f"-I{rel_path}/include/"],
                 )
-                build.sh_append_flags(
+                build.sh_append_quoted_flags(
                     configure_flags,
                     f"{var_prefix}_LIBS",
                     dep_ldflags,
                 )
             else:
-                build.sh_append_flags(
+                build.sh_append_quoted_flags(
                     configure_flags,
                     "CFLAGS",
-                    f"-I{rel_path}/include/",
+                    [f"-I{rel_path}/include/"],
                 )
-                build.sh_append_flags(
+                build.sh_append_quoted_ldflags(
                     configure_flags,
-                    f"LDFLAGS",
                     dep_ldflags,
                 )
 
-            ldflags = f"-L{rel_path}/lib/"
+            ldflags = [f"-L{rel_path}/lib/"]
 
             if platform.system() == "Darwin":
                 # In case ./configure tries to compile and test a program
@@ -1067,9 +1066,9 @@ class BundledCPackage(BuildSystemMakePackage):
                 # at its install_name location.
                 configure_flags["DYLD_FALLBACK_LIBRARY_PATH"] = root
             else:
-                ldflags += f'" "-Wl,-rpath-link,{rel_path}/lib'
+                ldflags.append(f"-Wl,-rpath-link,{rel_path}/lib")
 
-            build.sh_append_flags(configure_flags, f"LDFLAGS", ldflags)
+            build.sh_append_quoted_ldflags(configure_flags, ldflags)
 
         elif build.is_stdlib(pkg):
             configure_flags[f"{var_prefix}_CFLAGS"] = (

--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -388,7 +388,7 @@ class BasePythonPackage(base.BasePackage):
             )
 
             if cflags:
-                build.sh_append_flags(env, "CFLAGS", cflags)
+                build.sh_append_quoted_flags(env, "CFLAGS", cflags)
 
             ldflags = build.sh_get_bundled_shlibs_ldflags(
                 build_deps,
@@ -396,7 +396,7 @@ class BasePythonPackage(base.BasePackage):
             )
 
             if ldflags:
-                build.sh_append_flags(env, "LDFLAGS", ldflags)
+                build.sh_append_quoted_ldflags(env, ldflags)
 
             binary = True
 

--- a/metapkg/targets/deb/build.py
+++ b/metapkg/targets/deb/build.py
@@ -11,6 +11,8 @@ import stat
 import subprocess
 import textwrap
 
+from cleo.io.outputs import stream_output as cleo_io_stream_output
+
 from metapkg import packages
 from metapkg import targets
 from metapkg import tools
@@ -598,12 +600,15 @@ class Build(targets.Build):
         else:
             workdir = self.get_source_abspath()
 
+        output = self._io.output
+        assert isinstance(output, cleo_io_stream_output.StreamOutput)
+
         tools.cmd(
             "apt-get",
             "update",
             env=env,
             cwd=str(workdir),
-            stdout=self._io.output.stream,
+            stdout=output.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -616,7 +621,7 @@ class Build(targets.Build):
             "devscripts",
             env=env,
             cwd=str(workdir),
-            stdout=self._io.output.stream,
+            stdout=output.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -628,7 +633,7 @@ class Build(targets.Build):
             str(self._debroot / "control"),
             env=env,
             cwd="/tmp",
-            stdout=self._io.output.stream,
+            stdout=output.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -640,7 +645,7 @@ class Build(targets.Build):
             "dpkg-buildpackage",
             *args,
             cwd=str(workdir),
-            stdout=self._io.output.stream,
+            stdout=output.stream,
             stderr=subprocess.STDOUT,
         )
 


### PR DESCRIPTION
Passing `LDFLAGS` is no longer always enough.  Pass link flags as
`-C link-arg=...` in `RUSTFLAGS` as well.
