### PR TITLE
Do not attempt to extract build requirements for setuptools

### DIFF
--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -273,7 +273,13 @@ def get_build_requires_from_srcdir(
         )
         sys_reqs = builder.build_system_requires
         env.install(sys_reqs)
-        pkg_reqs = builder.get_requires_for_build("wheel")
+        if package.name == "pypkg-setuptools":
+            # get_requires_for_build crashes on setuptools with
+            # 'MinimalDistribution' object has no attribute 'entry_points'
+            # but we know that setuptools has no external build deps
+            pkg_reqs = set()
+        else:
+            pkg_reqs = builder.get_requires_for_build("wheel")
 
     deps = []
     for req in sys_reqs | pkg_reqs:


### PR DESCRIPTION
`setuptools` has some not very sane bootstrap setup and so using
`build`'s `get_requires_for_build` crashes hard with an inscrutable

    'MinimalDistribution' object has no attribute 'entry_points'

We know that `setuptools` has no build-time dependencies outside of
what's in `pyproject.toml`, so just assume so.
