### PR TITLE
Allow specifying features/extras on root module

### DIFF
--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -182,7 +182,7 @@ class Build(base.Command):
         af_repo.bundle_repo.add_package(root)
 
         target_capabilities = target.get_capabilities()
-        extras = [f"capability-{c}" for c in target_capabilities]
+        extras = [f"capability-{c}" for c in target_capabilities] + list(root_pkg.features)
 
         repo_pool = af_repo.Pool()
         repo_pool.add_repository(target.get_package_repository())

--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -182,7 +182,9 @@ class Build(base.Command):
         af_repo.bundle_repo.add_package(root)
 
         target_capabilities = target.get_capabilities()
-        extras = [f"capability-{c}" for c in target_capabilities] + list(root_pkg.features)
+        extras = [f"capability-{c}" for c in target_capabilities] + list(
+            root_pkg.features
+        )
 
         repo_pool = af_repo.Pool()
         repo_pool.add_repository(target.get_package_repository())


### PR DESCRIPTION
Surprisingly, only this is required for features on root modules to be taken into account when picking which dependency groups need to be enabled on Python packages.
