### PR TITLE
Cap setuptools below 70.2.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ setup(
         "distro~=1.9.0",
         "requests~=2.31.0",
         "poetry~=1.2.0",
+        # Poetry <1.5.0 is not compatible with setuptools>=70.2.0
+        # See https://github.com/pypa/setuptools/pull/4434
+        "setuptools<70.2.0",
         "distlib~=0.3.8",
         'python-magic~=0.4.26; platform_system=="Linux" or (platform_machine!="x86_64" and platform_machine!="AMD64")',
         'python-magic-bin~=0.4.14; platform_system!="Linux" and platform_machine!="arm64"',


### PR DESCRIPTION
[setuptools 70.2.0](https://github.com/pypa/setuptools/pull/4434) started to use `canonicalize_version(…, strip_trailing_zero=True)`, which is only added in [Poetry 1.5.0](https://github.com/python-poetry/poetry-core/commit/43fd7fe62676421b3661c96844b5d7cf49b87c07) while we’re pinned to `poetry~=1.2.0`

[Sample CI with EdgeDB](https://github.com/edgedb/edgedb/actions/runs/10011647710)