### PR TITLE
Depend on recent `packaging` explicitly

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ setup(
     install_requires=[
         "build~=1.2.1",
         "distro~=1.9.0",
+        "packaging>=24.1",
         "requests~=2.31.0",
         "poetry~=1.2.0",
         "distlib~=0.3.8",


### PR DESCRIPTION
Required by setuptools-70.2.0+
