### PR TITLE
Allow binary of maturin

### DIFF
--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -311,6 +311,7 @@ def is_build_system_bootstrap_package(
     return pkgname in {
         "wheel",
         "setuptools",
+        "maturin",
     }
 
 


### PR DESCRIPTION
The `maturin` command is used now in building pydantic-core.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/10223624841)