### PR TITLE
Poetry upgrade

### DIFF
--- a/metapkg/app.py
+++ b/metapkg/app.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from cleo.io.outputs.output import Output
 
 
-class App(BaseApplication):  # type: ignore
+class App(BaseApplication):
     def __init__(self) -> None:
         super().__init__(metapkg.__name__, metapkg.__version__)
 
@@ -38,4 +38,4 @@ def main() -> int:
         cmd = getattr(metapkg_commands, cmd_name)
         app.add(cmd())
 
-    return app.run()  # type: ignore
+    return app.run()

--- a/metapkg/commands/base.py
+++ b/metapkg/commands/base.py
@@ -1,5 +1,5 @@
 from cleo.commands import command as cleo_command
 
 
-class Command(cleo_command.Command):  # type: ignore
+class Command(cleo_command.Command):
     pass

--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -399,6 +399,9 @@ class Build(base.Command):
         return reresolve_deps
 
     def _clamp_rlimit_nofile(self) -> None:
+        if sys.platform == "win32":
+            return
+
         try:
             import resource
         except ImportError:

--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -15,6 +15,7 @@ from cleo.helpers import argument, option
 from poetry import puzzle
 from poetry.core.packages import dependency as poetry_dep
 from poetry.core.packages import project_package
+from poetry.repositories import repository_pool as poetry_repository_pool
 from poetry.utils import env as poetry_env
 
 from metapkg import targets
@@ -261,11 +262,17 @@ class Build(base.Command):
 
         repo_pool = af_repo.Pool()
         repo_pool.add_repository(target.get_package_repository())
-        repo_pool.add_repository(af_repo.bundle_repo, secondary=True)
+        repo_pool.add_repository(
+            af_repo.bundle_repo,
+            priority=poetry_repository_pool.Priority.SUPPLEMENTAL,
+        )
 
         item_repo = root_pkg.get_package_repository(target, io=self.io)
         if item_repo is not None and item_repo is not af_repo.bundle_repo:
-            repo_pool.add_repository(item_repo, secondary=True)
+            repo_pool.add_repository(
+                item_repo,
+                priority=poetry_repository_pool.Priority.SUPPLEMENTAL,
+            )
 
         provider = af_repo.Provider(root, repo_pool, self.io, extras=extras)
         solver = puzzle.Solver(root, repo_pool, [], [], self.io)
@@ -274,7 +281,7 @@ class Build(base.Command):
 
         pkg_map: dict[mpkg_base.NormalizedName, mpkg_base.BasePackage] = {}
         graph = {}
-        for dep_package in resolution[0]:
+        for dep_package in resolution:
             pkg_map[dep_package.name] = cast(
                 mpkg_base.BasePackage, dep_package
             )
@@ -314,7 +321,7 @@ class Build(base.Command):
 
         pkg_map = {}
         graph = {}
-        for dep_package in resolution[0]:
+        for dep_package in resolution:
             pkg_map[dep_package.name] = cast(
                 mpkg_base.BasePackage, dep_package
             )

--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -10,7 +10,9 @@ import pathlib
 import sys
 import tempfile
 
-from poetry import mixology
+from cleo.helpers import argument, option
+
+from poetry import puzzle
 from poetry.core.packages import dependency as poetry_dep
 from poetry.core.packages import project_package
 from poetry.utils import env as poetry_env
@@ -24,32 +26,98 @@ from . import base
 
 
 class Build(base.Command):
-    """Build the specified package
-
-    build
-        { name : Package to build. }
-        { --jobs= : Use up to N processes in parallel to build. }
-        { --dest= : Destination path. }
-        { --keepwork : Do not remove the work directory. }
-        { --generic : Build a generic target. }
-        { --arch= : Target architecture, if different from host. }
-        { --libc= : Libc to target. }
-        { --build-source : Build source packages. }
-        { --build-debug : Build debug symbol packages. }
-        { --release : Whether this build is a release. }
-        { --source-ref= : Source version to build (VCS ref or tarball version). }
-        { --pkg-revision= : Override package revision number (defaults to 1). }
-        { --pkg-subdist= : Set package sub-distribution (e.g. nightly). }
-        { --pkg-tags= : Comma-separated list of key=value pairs to include in
-                        pckage metadata. }
-        { --pkg-compression= : Comma-separated list of compression encodings to
-                               apply if building for the specified target
-                               produces a tarball (defaults to gzip,zstd). }
-        { --extra-optimizations : Enable extra optimization
-                                  (increases build times). }
-    """
-
-    help = """Builds the specified package on the current platform."""
+    name = "build"
+    description = """Builds the specified package on the current platform."""
+    arguments = [
+        argument(
+            "name",
+            description="Package to build",
+        ),
+    ]
+    options = [
+        option(
+            "jobs",
+            description="Use up to N processes in parallel to build.",
+            flag=False,
+        ),
+        option(
+            "dest",
+            description="Destination path.",
+            flag=False,
+        ),
+        option(
+            "keepwork",
+            description="Do not remove the work directory upon exit.",
+            flag=True,
+        ),
+        option(
+            "generic",
+            description="Build a generic artifact.",
+            flag=True,
+        ),
+        option(
+            "arch",
+            description="Target architecture, if different from host.",
+            flag=False,
+        ),
+        option(
+            "libc",
+            description="Libc to target.",
+            flag=False,
+        ),
+        option(
+            "build-source",
+            description="Build source packages.",
+            flag=True,
+        ),
+        option(
+            "build-debug",
+            description="Build debug packages.",
+            flag=True,
+        ),
+        option(
+            "release",
+            description="Whether this build is a release.",
+            flag=True,
+        ),
+        option(
+            "source-ref",
+            description="Source version to build (VCS ref or tarball version).",
+            flag=False,
+        ),
+        option(
+            "pkg-revision",
+            description="Override package revision number (defaults to 1).",
+            flag=False,
+        ),
+        option(
+            "pkg-subdist",
+            description="Set package sub-distribution (e.g. nightly).",
+            flag=False,
+        ),
+        option(
+            "pkg-tags",
+            description=(
+                "Comma-separated list of key=value pairs to include "
+                "in package metadata."
+            ),
+            flag=False,
+        ),
+        option(
+            "pkg-compression",
+            description=(
+                "Comma-separated list of compression encodings to apply "
+                "if building for the specified target produces a tarball "
+                "(defaults to gzip,zstd)."
+            ),
+            flag=False,
+        ),
+        option(
+            "extra-optimizations",
+            description="Enable extra optimization (increases build times).",
+            flag=True,
+        ),
+    ]
 
     _loggers = ["metapkg.build"]
 
@@ -200,11 +268,13 @@ class Build(base.Command):
             repo_pool.add_repository(item_repo, secondary=True)
 
         provider = af_repo.Provider(root, repo_pool, self.io, extras=extras)
-        resolution = mixology.resolve_version(root, provider)
+        solver = puzzle.Solver(root, repo_pool, [], [], self.io)
+        solver._provider = provider
+        resolution = solver._solve()
 
         pkg_map: dict[mpkg_base.NormalizedName, mpkg_base.BasePackage] = {}
         graph = {}
-        for dep_package in resolution.packages:
+        for dep_package in resolution[0]:
             pkg_map[dep_package.name] = cast(
                 mpkg_base.BasePackage, dep_package
             )
@@ -234,11 +304,13 @@ class Build(base.Command):
             include_build_reqs=True,
             extras=extras,
         )
-        resolution = mixology.resolve_version(build_root, provider)
+        solver = puzzle.Solver(build_root, repo_pool, [], [], self.io)
+        solver._provider = provider
+        resolution = solver._solve()
 
         pkg_map = {}
         graph = {}
-        for dep_package in resolution.packages:
+        for dep_package in resolution[0]:
             pkg_map[dep_package.name] = cast(
                 mpkg_base.BasePackage, dep_package
             )
@@ -324,7 +396,7 @@ class Build(base.Command):
             try:
                 fno_soft, fno_hard = resource.getrlimit(resource.RLIMIT_NOFILE)
             except resource.error:
-                self.io.write_warning_line("could not read RLIMIT_NOFILE")
+                self.io.write_error_line("could not read RLIMIT_NOFILE")
             else:
                 if fno_soft > 8192 or fno_hard > 8192:
                     try:
@@ -333,6 +405,6 @@ class Build(base.Command):
                             (min(8192, fno_soft), min(8192, fno_hard)),
                         )
                     except resource.error:
-                        self.io.write_warning_line(
+                        self.io.write_error_line(
                             "could not read RLIMIT_NOFILE"
                         )

--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -306,7 +306,11 @@ class Build(base.Command):
         )
         solver = puzzle.Solver(build_root, repo_pool, [], [], self.io)
         solver._provider = provider
-        resolution = solver._solve()
+        mpkg_base.all_requires_include_build_reqs = True
+        try:
+            resolution = solver._solve()
+        finally:
+            mpkg_base.all_requires_include_build_reqs = False
 
         pkg_map = {}
         graph = {}

--- a/metapkg/commands/metadata.py
+++ b/metapkg/commands/metadata.py
@@ -5,6 +5,7 @@ import json
 import pathlib
 import sys
 
+from cleo.helpers import argument, option
 from poetry.utils import env as poetry_env
 
 from metapkg import targets
@@ -13,18 +14,41 @@ from . import base
 
 
 class Metadata(base.Command):
-    """Show metadata for a given package and version.
-
-    metadata
-        { name : Package to show metadata for. }
-        { --generic : Build a generic target. }
-        { --libc= : Libc to target. }
-        { --release : Whether this build is a release. }
-        { --source-ref= : Source version to build (VCS ref or tarball version). }
-        { --pkg-revision= : Override package revision number (defaults to 1). }
-    """
-
-    help = """Returns metadata for a given package and version."""
+    name = "metadata"
+    description = """Returns metadata for a given package and version"""
+    arguments = [
+        argument(
+            "name",
+            description="Package to build",
+        ),
+    ]
+    options = [
+        option(
+            "generic",
+            description="Build a generic artifact",
+            flag=True,
+        ),
+        option(
+            "libc",
+            description="Libc to target",
+            flag=False,
+        ),
+        option(
+            "release",
+            description="Whether this build is a release",
+            flag=True,
+        ),
+        option(
+            "source-ref",
+            description="Source version to build (VCS ref or tarball version)",
+            flag=False,
+        ),
+        option(
+            "pkg-revision",
+            description="Override package revision number (defaults to 1)",
+            flag=False,
+        ),
+    ]
 
     _loggers = ["metapkg.metadata"]
 

--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -3,6 +3,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     ClassVar,
+    Iterable,
     Literal,
     Mapping,
     Sequence,
@@ -85,7 +86,45 @@ class MetaPackage:
     dependencies: dict[str, str]
 
 
-class BasePackage(poetry_pkg.Package):
+class PackageWithPrettyVersion(poetry_pkg.Package):
+    def __init__(
+        self,
+        name: str,
+        version: str | poetry_version.Version,
+        source_type: str | None = None,
+        source_url: str | None = None,
+        source_reference: str | None = None,
+        source_resolved_reference: str | None = None,
+        source_subdirectory: str | None = None,
+        features: Iterable[str] | None = None,
+        develop: bool = False,
+        yanked: str | bool = False,
+        *,
+        pretty_version: str | None = None,
+    ) -> None:
+        super().__init__(
+            name=name,
+            version=version,
+            source_type=source_type,
+            source_url=source_url,
+            source_reference=source_reference,
+            source_resolved_reference=source_resolved_reference,
+            source_subdirectory=source_subdirectory,
+            features=features,
+            develop=develop,
+            yanked=yanked,
+        )
+
+        if pretty_version:
+            self._pretty_version = pretty_version
+        else:
+            if isinstance(version, poetry_version.Version):
+                self._pretty_version = version.text
+            else:
+                self._pretty_version = version
+
+
+class BasePackage(PackageWithPrettyVersion):
     @property
     def slot_suffix(self) -> str:
         return ""
@@ -455,7 +494,7 @@ BundledPackage_T = TypeVar("BundledPackage_T", bound="BundledPackage")
 RequirementsSpec = Union[
     list[str | poetry_dep.Dependency],
     Mapping[
-        str | poetry_constr.VersionConstraint,
+        str | poetry_version.VersionConstraint,
         Sequence[str | poetry_dep.Dependency],
     ],
 ]
@@ -544,15 +583,15 @@ class BundledPackage(BasePackage):
                     **cls.get_source_url_variables(version),
                 )
                 extras = af_sources.SourceExtraDecl(
-                    source.get("extras", {})
-                )  # type: ignore
+                    source.get("extras", {})  # type: ignore
+                )
                 if extras:
                     if "version" not in extras:
                         extras["version"] = version
                 else:
                     extras = af_sources.SourceExtraDecl({"version": version})
 
-                if "vcs_version" not in extras:
+                if "vcs_version" not in extras and "version" in extras:
                     extras["vcs_version"] = cls.to_vcs_version(
                         extras["version"]
                     )
@@ -633,33 +672,6 @@ class BundledPackage(BasePackage):
         return tools.git.Git(repo_dir)
 
     @classmethod
-    def resolve_vcs_version(
-        cls,
-        io: cleo_io.IO,
-        repo: tools.git.Git,
-        version: str | None = None,
-    ) -> str:
-        rev: str
-
-        if version is None:
-            rev = repo.rev_parse("HEAD").strip()
-        else:
-            output = repo.run("ls-remote", repo.remote_url(), version)
-
-            if output:
-                rev, _ = output.split()
-                # If it's a tag, resolve the underlying commit.
-                if repo.run("cat-file", "-t", rev) == "tag":
-                    rev = repo.run("rev-list", "-n", "1", rev)
-            else:
-                # The name can be a branch or tag, so we attempt to look it up
-                # with ls-remote. If we don't find anything, we assume it's a
-                # commit hash.
-                rev = version
-
-        return rev
-
-    @classmethod
     def get_next_feature_version(
         cls,
         version: poetry_version.Version,
@@ -701,9 +713,9 @@ class BundledPackage(BasePackage):
                     local=None,
                     pre=None,
                     dev=poetry_pep440.ReleaseTag("dev", int(commits)),
-                ).to_string(short=False)
+                ).to_string()
             else:
-                ver = parsed_ver.to_string(short=False)
+                ver = parsed_ver.to_string()
 
         return ver
 
@@ -722,6 +734,7 @@ class BundledPackage(BasePackage):
         sources = list(cls._get_sources(version))
         vcs_source = cls.get_vcs_source(io, version)
         is_git = vcs_source is not None
+        git_date = ""
 
         if vcs_source is not None:
             sources[0] = vcs_source
@@ -730,7 +743,7 @@ class BundledPackage(BasePackage):
                 vcs_version = cls.to_vcs_version(version)
             else:
                 vcs_version = None
-            source_version = cls.resolve_vcs_version(io, repo, vcs_version)
+            source_version = repo.peel_ref(vcs_version or "HEAD")
             version = cls.version_from_vcs_version(
                 io, repo, source_version, is_release
             )
@@ -745,7 +758,6 @@ class BundledPackage(BasePackage):
             )
         elif version is not None:
             source_version = version
-            git_date = ""
         elif isinstance(sources[0], af_sources.LocalSource):
             source_dir = sources[0].url
             version = cls.version_from_source(pathlib.Path(source_dir))
@@ -850,15 +862,11 @@ class BundledPackage(BasePackage):
                 f"{type(self)!r} does not define the required "
                 f"title attribute"
             )
-        if not isinstance(version, poetry_version.Version):
-            self._pretty_version = pretty_version or version
-        else:
-            self._pretty_version = pretty_version or version.text
 
         if name is None:
             name = canonicalize_name(self.__class__.ident)
 
-        super().__init__(name, version)
+        super().__init__(name, version, pretty_version=pretty_version)
 
         if requires is not None:
             reqs = list(requires)
@@ -1248,7 +1256,7 @@ def merge_requirements(
     *specs: RequirementsSpec,
 ) -> RequirementsSpec:
     result: collections.defaultdict[
-        str | poetry_constr.VersionConstraint,
+        str | poetry_version.VersionConstraint,
         list[str | poetry_dep.Dependency],
     ] = collections.defaultdict(list)
     for spec in specs:
@@ -1280,7 +1288,7 @@ def _get_bundled_pkg_config_meta(name: str) -> PkgConfigMeta:
 def _get_pkg_in_bundle_repo(dep: poetry_dep.Dependency) -> poetry_pkg.Package:
     packages = repository.bundle_repo.find_packages(dep)
     if not packages:
-        raise poetry_repo_exc.PackageNotFound(
+        raise poetry_repo_exc.PackageNotFoundError(
             f"package {dep.pretty_name} not found in bundled repo."
         )
 
@@ -1588,7 +1596,7 @@ class BundledCAutoconfPackage(BundledCPackage):
         super().configure_dependency(build, dep, conf_args, conf_env, wd=wd)
         try:
             pkg_config_meta = self.get_dep_pkg_config_meta(dep)
-        except poetry_repo_exc.PackageNotFound:
+        except poetry_repo_exc.PackageNotFoundError:
             # This is a preinstalled system build-time package,
             # for which we have no in-tree definition.
             return

--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -56,6 +56,7 @@ get_build_requirements = repository.get_build_requirements
 set_build_requirements = repository.set_build_requirements
 canonicalize_name = packaging.utils.canonicalize_name
 NormalizedName = packaging.utils.NormalizedName
+all_requires_include_build_reqs: bool = False
 
 
 Args: TypeAlias = dict[str, Union[str, pathlib.Path, None]]
@@ -422,6 +423,15 @@ class BasePackage(poetry_pkg.Package):
 
     def get_package_layout(self, build: targets.Build) -> PackageFileLayout:
         return PackageFileLayout.REGULAR
+
+    @property
+    def all_requires(
+        self,
+    ) -> list[poetry_dep.Dependency]:
+        if all_requires_include_build_reqs:
+            return super().all_requires + get_build_requirements(self)
+        else:
+            return super().all_requires
 
 
 @dataclasses.dataclass(kw_only=True)

--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -850,11 +850,15 @@ class BundledPackage(BasePackage):
                 f"{type(self)!r} does not define the required "
                 f"title attribute"
             )
+        if not isinstance(version, poetry_version.Version):
+            self._pretty_version = pretty_version or version
+        else:
+            self._pretty_version = pretty_version or version.text
 
         if name is None:
             name = canonicalize_name(self.__class__.ident)
 
-        super().__init__(name, version, pretty_version=pretty_version)
+        super().__init__(name, version)
 
         if requires is not None:
             reqs = list(requires)
@@ -902,6 +906,10 @@ class BundledPackage(BasePackage):
                     poetry_dep.Dependency(self.name, self.version)
                 )
                 repository.bundle_repo.add_package(pkg)
+
+    @property
+    def pretty_version(self) -> str:
+        return self._pretty_version
 
     def _get_requirements(
         self,

--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -35,9 +35,8 @@ import packaging.utils
 from poetry.core.packages import dependency as poetry_dep
 from poetry.core.packages import dependency_group as poetry_depgroup
 from poetry.core.packages import package as poetry_pkg
-from poetry.core.semver import version as poetry_version
 from poetry.core.version import pep440 as poetry_pep440
-from poetry.core.constraints import version as poetry_constr
+from poetry.core.constraints import version as poetry_version
 from poetry.core.version.pep440 import segments as poetry_pep440_segments
 from poetry.core.spdx import helpers as poetry_spdx_helpers
 from poetry.repositories import exceptions as poetry_repo_exc
@@ -855,9 +854,11 @@ class BundledPackage(BasePackage):
         reqs.extend(self.get_requirements())
 
         if reqs:
-            if poetry_depgroup.MAIN_GROUP not in self._dependency_groups:
-                self._dependency_groups[poetry_depgroup.MAIN_GROUP] = (
-                    poetry_depgroup.DependencyGroup(poetry_depgroup.MAIN_GROUP)
+            if not self.has_dependency_group(poetry_depgroup.MAIN_GROUP):
+                self.add_dependency_group(
+                    poetry_depgroup.DependencyGroup(
+                        poetry_depgroup.MAIN_GROUP
+                    ),
                 )
 
             main_group = self._dependency_groups[poetry_depgroup.MAIN_GROUP]
@@ -906,7 +907,7 @@ class BundledPackage(BasePackage):
         else:
             for ver, ver_reqs in spec.items():
                 if isinstance(ver, str):
-                    ver = poetry_constr.parse_constraint(ver)
+                    ver = poetry_version.parse_constraint(ver)
                 if ver.allows(self.version):
                     req_spec.extend(ver_reqs)
 

--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -91,17 +91,14 @@ class PyPiRepository(pypi_repository.PyPiRepository):
         self,
         name: str,
         version: poetry_version.Version,
-        extras: list[str] | None = None,
     ) -> poetry_pkg.Package:
         if name.startswith("pypkg-"):
             name = name[len("pypkg-") :]
 
         try:
-            orig_package = super().package(
-                name=name, version=version, extras=extras
-            )
+            orig_package = super().package(name=name, version=version)
         except ValueError as e:
-            raise poetry_repo_exc.PackageNotFound(
+            raise poetry_repo_exc.PackageNotFoundError(
                 f"Package {name} ({version}) not found."
             ) from e
 
@@ -202,7 +199,7 @@ class PyPiRepository(pypi_repository.PyPiRepository):
             name = name[len("pypkg-") :]
         json_data = self._get(f"pypi/{name}/{version}/json")
         if json_data is None:
-            raise poetry_repo_exc.PackageNotFound(
+            raise poetry_repo_exc.PackageNotFoundError(
                 f"Package {name} ({version}) not found."
             )
         else:
@@ -628,7 +625,7 @@ class BundledPythonPackage(BasePythonPackage, base.BundledPackage):
             name=name,
             pretty_version=pretty_version,
             requires=requires,
-            source_version=cls.resolve_vcs_version(io, repo),
+            source_version=repo.rev_parse("HEAD"),
         )
         package.dist_name = dist.name
         repository.set_build_requirements(

--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -14,9 +14,10 @@ import textwrap
 
 from poetry.core.packages import dependency as poetry_dep
 from poetry.core.packages import package as poetry_pkg
-from poetry.core.semver import version as poetry_version
+from poetry.core.constraints import version as poetry_version
 from poetry.repositories import pypi_repository
 from poetry.repositories import exceptions as poetry_repo_exc
+from poetry.utils import cache as poetry_cache
 
 import build as pypa_build
 import build.env as pypa_build_env
@@ -55,6 +56,9 @@ class PyPiRepository(pypi_repository.PyPiRepository):
             "flit-core": FlitCore,
             "tomli": Tomli,
         }
+        self._dep_cache: poetry_cache.FileCache[list[str]] = (
+            poetry_cache.FileCache(path=self._cache_dir)
+        )
 
     def register_package_impl(
         self,
@@ -145,7 +149,7 @@ class PyPiRepository(pypi_repository.PyPiRepository):
         if self._disable_cache:
             build_reqs = self._get_build_requires(package)
         else:
-            build_reqs = self._cache.remember_forever(
+            build_reqs = self._dep_cache.remember(
                 f"{package.unique_name}:build-requirements",
                 lambda: self._get_build_requires(package),
             )
@@ -196,19 +200,6 @@ class PyPiRepository(pypi_repository.PyPiRepository):
     ) -> dict[str, Any]:
         if name.startswith("pypkg-"):
             name = name[len("pypkg-") :]
-        if self._disable_cache:
-            pypi_info = self._get_pypi_info(name, version)
-        else:
-            pypi_info = self._cache.remember_forever(
-                f"{name}:{version}:pypi-info",
-                lambda: self._get_pypi_info(name, version),
-            )
-
-        return pypi_info
-
-    def _get_pypi_info(
-        self, name: str, version: poetry_version.Version
-    ) -> dict[str, Any]:
         json_data = self._get(f"pypi/{name}/{version}/json")
         if json_data is None:
             raise poetry_repo_exc.PackageNotFound(

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -77,7 +77,7 @@ class Provider(poetry_provider.Provider):
     def __init__(
         self,
         package: poetry_pkg.Package,
-        pool: poetry_pool.Pool,
+        pool: poetry_pool.RepositoryPool,
         io: cleo_io.IO,
         *,
         installed: list[poetry_pkg.Package] | None = None,

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 from typing import (
     TYPE_CHECKING,
+    Collection,
     Iterator,
 )
 
@@ -29,35 +30,35 @@ if TYPE_CHECKING:
     from cleo.io import io as cleo_io
 
 
-def _DependencyCache_search_for(
-    self: poetry_versolver.DependencyCache,
-    dependency: poetry_dep.Dependency,
-) -> list[poetry_deppkg.DependencyPackage]:
-    key = (
-        dependency.complete_name,
-        dependency.pretty_constraint,
-        dependency.source_type,
-        dependency.source_url,
-        dependency.source_reference,
-        dependency.source_subdirectory,
-    )
+# def _DependencyCache_search_for(
+#     self: poetry_versolver.DependencyCache,
+#     dependency: poetry_dep.Dependency,
+# ) -> list[poetry_deppkg.DependencyPackage]:
+#     key = (
+#         dependency.complete_name,
+#         dependency.pretty_constraint,
+#         dependency.source_type,
+#         dependency.source_url,
+#         dependency.source_reference,
+#         dependency.source_subdirectory,
+#     )
 
-    packages = self.cache.get(key)  # type: ignore
-    if packages is None:
-        packages = self.provider.search_for(dependency)
-    else:
-        packages = [
-            p
-            for p in packages
-            if dependency.constraint.allows(p.package.version)
-        ]
+#     packages = self._cache.get(key)  # type: ignore [arg-type]
+#     if packages is None:
+#         packages = self._provider.search_for(dependency)
+#     else:
+#         packages = [
+#             p
+#             for p in packages
+#             if dependency.constraint.allows(p.package.version)
+#         ]
 
-    self.cache[key] = packages  # type: ignore
+#     self._cache[key] = packages  # type: ignore [index]
 
-    return packages
+#     return packages
 
 
-poetry_versolver.DependencyCache._search_for = _DependencyCache_search_for  # type: ignore
+# poetry_versolver.DependencyCache._search_for = _DependencyCache_search_for  # type: ignore
 
 
 class Pool(poetry_pool.RepositoryPool):
@@ -68,6 +69,16 @@ class BundleRepository(poetry_repo.Repository):
     def add_package(self, package: poetry_pkg.Package) -> None:
         if not self.has_package(package):
             super().add_package(package)
+
+    def remove_package(self, package: poetry_pkg.Package) -> None:
+        index = None
+        for i, repo_package in enumerate(self.packages):
+            if repo_package == package:
+                index = i
+                break
+
+        if index is not None:
+            del self._packages[index]
 
 
 bundle_repo = BundleRepository("bundled")
@@ -80,12 +91,14 @@ class Provider(poetry_provider.Provider):
         pool: poetry_pool.RepositoryPool,
         io: cleo_io.IO,
         *,
-        installed: list[poetry_pkg.Package] | None = None,
         locked: list[poetry_pkg.Package] | None = None,
+        active_root_extras: (
+            Collection[packaging.utils.NormalizedName] | None
+        ) = None,
         include_build_reqs: bool = False,
         extras: list[str] | None = None,
     ) -> None:
-        super().__init__(package, pool, io, installed=installed, locked=locked)
+        super().__init__(package, pool, io, locked=locked)
         self.include_build_reqs = include_build_reqs
         self._active_extras = set(extras) if extras else set()
 
@@ -150,25 +163,25 @@ class Provider(poetry_provider.Provider):
 
     def incompatibilities_for(
         self,
-        package: poetry_deppkg.DependencyPackage,
+        dependency_package: poetry_deppkg.DependencyPackage,
     ) -> list[poetry_incompat.Incompatibility]:
         if self.include_build_reqs:
-            breqs = get_build_requirements(package.package)
-            with extra_requirements(package.package, breqs):
-                return super().incompatibilities_for(package)
+            breqs = get_build_requirements(dependency_package.package)
+            with extra_requirements(dependency_package.package, breqs):
+                return super().incompatibilities_for(dependency_package)
         else:
-            return super().incompatibilities_for(package)
+            return super().incompatibilities_for(dependency_package)
 
     def complete_package(
         self,
-        package: poetry_deppkg.DependencyPackage,
+        dependency_package: poetry_deppkg.DependencyPackage,
     ) -> poetry_deppkg.DependencyPackage:
-        chain = [package.package.all_requires]
-        build_requires = get_build_requirements(package.package)
+        chain = [dependency_package.package.all_requires]
+        build_requires = get_build_requirements(dependency_package.package)
         if build_requires:
             chain.append(build_requires)
 
-        pkg = super().complete_package(package)
+        pkg = super().complete_package(dependency_package)
 
         for dep in itertools.chain.from_iterable(chain):
             dep_in_extras = {str(e) for e in dep.in_extras}

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -11,13 +11,11 @@ import pathlib
 
 import packaging.utils
 
-from poetry.repositories import exceptions as poetry_repo_exc
 from poetry.repositories import repository_pool as poetry_pool
 from poetry.repositories import repository as poetry_repo
 from poetry.core.packages import dependency as poetry_dep
 from poetry.core.packages import dependency_group as poetry_depgroup
 from poetry.core.packages import vcs_dependency as poetry_vcsdep
-from poetry.core.constraints import version as poetry_version
 from poetry.packages import dependency_package as poetry_deppkg
 from poetry.core.packages import package as poetry_pkg
 from poetry.mixology import incompatibility as poetry_incompat
@@ -64,36 +62,6 @@ poetry_versolver.DependencyCache._search_for = _DependencyCache_search_for  # ty
 
 class Pool(poetry_pool.RepositoryPool):
     pass
-    # def _package(
-    #     self,
-    #     name: str,
-    #     version: poetry_version.Version,
-    #     extras: list[str] | None = None,
-    #     repository_name: str | None = None,
-    # ) -> poetry_pkg.Package:
-    #     for repo in self.repositories:
-    #         try:
-    #             package = repo.package(name, version, extras=extras)
-    #         except poetry_repo_exc.PackageNotFound:
-    #             continue
-    #         if package:
-    #             self._packages.append(package)
-
-    #             return package
-
-    #     raise poetry_repo_exc.PackageNotFound(
-    #         f"Package {name} ({version}) not found."
-    #     )
-
-    # def find_packages(
-    #     self, dependency: poetry_dep.Dependency
-    # ) -> list[poetry_pkg.Package]:
-    #     for repo in self.repositories:
-    #         packages = repo.find_packages(dependency)
-    #         if packages:
-    #             return packages
-
-    #     return []
 
 
 class BundleRepository(poetry_repo.Repository):

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -12,12 +12,12 @@ import pathlib
 import packaging.utils
 
 from poetry.repositories import exceptions as poetry_repo_exc
-from poetry.repositories import pool as poetry_pool
+from poetry.repositories import repository_pool as poetry_pool
 from poetry.repositories import repository as poetry_repo
 from poetry.core.packages import dependency as poetry_dep
 from poetry.core.packages import dependency_group as poetry_depgroup
 from poetry.core.packages import vcs_dependency as poetry_vcsdep
-from poetry.core.semver import version as poetry_version
+from poetry.core.constraints import version as poetry_version
 from poetry.packages import dependency_package as poetry_deppkg
 from poetry.core.packages import package as poetry_pkg
 from poetry.mixology import incompatibility as poetry_incompat
@@ -62,38 +62,38 @@ def _DependencyCache_search_for(
 poetry_versolver.DependencyCache._search_for = _DependencyCache_search_for  # type: ignore
 
 
-class Pool(poetry_pool.Pool):
-    def package(
-        self,
-        name: str,
-        version: poetry_version.Version,
-        extras: list[str] | None = None,
-        repository: str | None = None,
-    ) -> poetry_pkg.Package:
-        for repo in self.repositories:
-            try:
-                package = repo.package(name, version, extras=extras)
-            except poetry_repo_exc.PackageNotFound:
-                continue
+class Pool(poetry_pool.RepositoryPool):
+    pass
+    # def _package(
+    #     self,
+    #     name: str,
+    #     version: poetry_version.Version,
+    #     extras: list[str] | None = None,
+    #     repository_name: str | None = None,
+    # ) -> poetry_pkg.Package:
+    #     for repo in self.repositories:
+    #         try:
+    #             package = repo.package(name, version, extras=extras)
+    #         except poetry_repo_exc.PackageNotFound:
+    #             continue
+    #         if package:
+    #             self._packages.append(package)
 
-            if package:
-                self._packages.append(package)
+    #             return package
 
-                return package
+    #     raise poetry_repo_exc.PackageNotFound(
+    #         f"Package {name} ({version}) not found."
+    #     )
 
-        raise poetry_repo_exc.PackageNotFound(
-            f"Package {name} ({version}) not found."
-        )
+    # def find_packages(
+    #     self, dependency: poetry_dep.Dependency
+    # ) -> list[poetry_pkg.Package]:
+    #     for repo in self.repositories:
+    #         packages = repo.find_packages(dependency)
+    #         if packages:
+    #             return packages
 
-    def find_packages(
-        self, dependency: poetry_dep.Dependency
-    ) -> list[poetry_pkg.Package]:
-        for repo in self.repositories:
-            packages = repo.find_packages(dependency)
-            if packages:
-                return packages
-
-        return []
+    #     return []
 
 
 class BundleRepository(poetry_repo.Repository):
@@ -112,10 +112,12 @@ class Provider(poetry_provider.Provider):
         pool: poetry_pool.Pool,
         io: cleo_io.IO,
         *,
+        installed: list[poetry_pkg.Package] | None = None,
+        locked: list[poetry_pkg.Package] | None = None,
         include_build_reqs: bool = False,
         extras: list[str] | None = None,
     ) -> None:
-        super().__init__(package, pool, io)
+        super().__init__(package, pool, io, installed=installed, locked=locked)
         self.include_build_reqs = include_build_reqs
         self._active_extras = set(extras) if extras else set()
 
@@ -125,7 +127,7 @@ class Provider(poetry_provider.Provider):
     ) -> poetry_pkg.Package:
         from . import python
 
-        pkg = self.get_package_from_vcs(
+        pkg = self._direct_origin.get_package_from_vcs(
             dependency.vcs,
             dependency.source,
             branch=dependency.branch,

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -20,7 +20,6 @@ from poetry.core.packages import vcs_dependency as poetry_vcsdep
 from poetry.packages import dependency_package as poetry_deppkg
 from poetry.core.packages import package as poetry_pkg
 from poetry.mixology import incompatibility as poetry_incompat
-from poetry.mixology import version_solver as poetry_versolver
 from poetry.puzzle import provider as poetry_provider
 from poetry.vcs import git as poetry_git
 
@@ -28,37 +27,6 @@ from . import sources as mpkg_sources
 
 if TYPE_CHECKING:
     from cleo.io import io as cleo_io
-
-
-# def _DependencyCache_search_for(
-#     self: poetry_versolver.DependencyCache,
-#     dependency: poetry_dep.Dependency,
-# ) -> list[poetry_deppkg.DependencyPackage]:
-#     key = (
-#         dependency.complete_name,
-#         dependency.pretty_constraint,
-#         dependency.source_type,
-#         dependency.source_url,
-#         dependency.source_reference,
-#         dependency.source_subdirectory,
-#     )
-
-#     packages = self._cache.get(key)  # type: ignore [arg-type]
-#     if packages is None:
-#         packages = self._provider.search_for(dependency)
-#     else:
-#         packages = [
-#             p
-#             for p in packages
-#             if dependency.constraint.allows(p.package.version)
-#         ]
-
-#     self._cache[key] = packages  # type: ignore [index]
-
-#     return packages
-
-
-# poetry_versolver.DependencyCache._search_for = _DependencyCache_search_for  # type: ignore
 
 
 class Pool(poetry_pool.RepositoryPool):

--- a/metapkg/packages/rust.py
+++ b/metapkg/packages/rust.py
@@ -58,7 +58,7 @@ class BundledRustPackage(base.BundledPackage):
                     pre=None,
                     dev=poetry_pep440.ReleaseTag("dev", int(commits)),
                 )
-                .to_string(short=False)
+                .to_string()
             )
 
         return version
@@ -126,9 +126,11 @@ class BundledAdHocRustPackage(BundledRustPackage):
     ) -> BundledAdHocRustPackage:
         sources = cls._get_sources(version)
 
-        if isinstance(sources[0], mpkg_sources.LocalSource):
-            source_dir = sources[0].url
-
+        if not isinstance(sources[0], mpkg_sources.LocalSource):
+            raise RuntimeError(
+                "expected bundled Rust package source to be local"
+            )
+        source_dir = sources[0].url
         version = cls.version_from_cargo(pathlib.Path(source_dir))
         if not revision:
             revision = "1"

--- a/metapkg/packages/rust.py
+++ b/metapkg/packages/rust.py
@@ -7,7 +7,7 @@ import pathlib
 import textwrap
 
 from poetry.core.packages import dependency as poetry_dep
-from poetry.core.semver import version as poetry_version
+from poetry.core.constraints import version as poetry_version
 from poetry.core.version import pep440 as poetry_pep440
 
 from metapkg import targets

--- a/metapkg/packages/sources.py
+++ b/metapkg/packages/sources.py
@@ -214,6 +214,7 @@ class HttpsSource(BaseSource):
             name_tpl = f"{pkg.unique_name}{{part}}.tar{{comp}}"
         src = self.download(io)
         copy = True
+        target_path = None
         if "archive" in self.extras and not self.extras["archive"]:
             copy = False
             comp = ".gz"
@@ -253,6 +254,7 @@ class HttpsSource(BaseSource):
             target_path = target_dir / name_tpl.format(part=part, comp=comp)
             shutil.copy(src, target_path)
 
+        assert target_path is not None
         return target_path
 
     def tarball(
@@ -592,7 +594,7 @@ def unpack_tar(
         else:
             raise ValueError(f"{archive.name} is not a supported archive")
 
-        with tarfile.open(archive, mode=f"r:{compression}") as tf:
+        with tarfile.open(archive, mode=f"r:{compression}") as tf:  # type: ignore
             for member in tf.getmembers():
                 if strip_components:
                     member_parts = pathlib.Path(member.name).parts

--- a/metapkg/targets/base.py
+++ b/metapkg/targets/base.py
@@ -545,7 +545,7 @@ class LinuxTarget(PosixTarget):
         with open(path, "rb") as f:
             header = f.read(18)
             signature = header[:4]
-            if signature == b"\x7FELF":
+            if signature == b"\x7fELF":
                 byteorder: Literal["big", "little"]
                 if header[5] == 2:
                     byteorder = "big"
@@ -2184,7 +2184,7 @@ class Build:
     ) -> None:
         new_paths = list(paths)
         if not args.get(key) and not ignore_env:
-            new_paths.insert(0, f"${{{key}}}")
+            new_paths.insert(0, f'"${{{key}}}"')
         self.sh_append_quoted_flags(args, key, new_paths, sep=sep)
 
     def sh_append_paths(
@@ -2212,7 +2212,7 @@ class Build:
     ) -> None:
         new_paths = list(paths)
         if not args.get(key) and not ignore_env:
-            new_paths.append(f"${{{key}}}")
+            new_paths.append(f'"${{{key}}}"')
         self.sh_prepend_quoted_flags(args, key, new_paths, sep=sep)
 
     def sh_prepend_paths(

--- a/metapkg/targets/base.py
+++ b/metapkg/targets/base.py
@@ -5,6 +5,7 @@ from typing import (
     Literal,
     Mapping,
     NamedTuple,
+    TextIO,
 )
 
 import collections
@@ -34,6 +35,7 @@ if TYPE_CHECKING:
     )
 
     from cleo.io.io import IO
+    from cleo.io.outputs.stream_output import StreamOutput
     from distro import distro
     from poetry.utils import env as poetry_env
     from poetry.repositories import repository as poetry_repo
@@ -758,6 +760,13 @@ class Build:
     @property
     def io(self) -> IO:
         return self._io
+
+    @property
+    def stream(self) -> TextIO:
+        output = self._io.output
+        if TYPE_CHECKING:
+            assert isinstance(output, StreamOutput)
+        return output.stream
 
     @property
     def root_package(self) -> mpkg_base.BundledPackage:

--- a/metapkg/targets/generic/build.py
+++ b/metapkg/targets/generic/build.py
@@ -393,7 +393,7 @@ class Build(targets.Build):
         tools.cmd(
             *command,
             cwd=str(self._srcroot),
-            stdout=self._io.output.stream,
+            stdout=self.stream,
             stderr=subprocess.STDOUT,
         )
 

--- a/metapkg/targets/macos/__init__.py
+++ b/metapkg/targets/macos/__init__.py
@@ -322,10 +322,10 @@ class MacOSTarget(generic.GenericTarget):
             signature = f.read(4)
         # Mach-O binaries
         return signature in {
-            b"\xFE\xED\xFA\xCE",
-            b"\xFE\xED\xFA\xCF",
-            b"\xCE\xFA\xED\xFE",
-            b"\xCF\xFA\xED\xFE",
+            b"\xfe\xed\xfa\xce",
+            b"\xfe\xed\xfa\xcf",
+            b"\xce\xfa\xed\xfe",
+            b"\xcf\xfa\xed\xfe",
         }
 
     def is_dynamically_linked(

--- a/metapkg/targets/package.py
+++ b/metapkg/targets/package.py
@@ -10,7 +10,7 @@ from poetry.core.packages import package as poetry_pkg
 from . import base
 
 if TYPE_CHECKING:
-    from poetry.core.semver.version import Version
+    from poetry.core.constraints.version import Version
 
 
 class SystemPackage(poetry_pkg.Package):

--- a/metapkg/targets/package.py
+++ b/metapkg/targets/package.py
@@ -5,7 +5,7 @@ from typing import Optional
 from typing import TypeVar
 from typing import Union
 
-from poetry.core.packages import package as poetry_pkg
+from metapkg.packages import base as mpkg_base
 
 from . import base
 
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
     from poetry.core.constraints.version import Version
 
 
-class SystemPackage(poetry_pkg.Package):
+class SystemPackage(mpkg_base.PackageWithPrettyVersion):
     def __init__(
         self,
         name: str,

--- a/metapkg/targets/rpm/__init__.py
+++ b/metapkg/targets/rpm/__init__.py
@@ -327,8 +327,6 @@ class AmazonLinuxTarget(RHEL7OrNewerTarget):
             "-y",
             spec,
             cwd=str(build.get_spec_root(relative_to="fsroot")),
-            stdout=build._io.output.stream,
-            stderr=subprocess.STDOUT,
         )
 
 

--- a/metapkg/targets/rpm/__init__.py
+++ b/metapkg/targets/rpm/__init__.py
@@ -243,7 +243,7 @@ class BaseRPMTarget(targets.FHSTarget, targets.LinuxDistroTarget):
             "rpm-build",
             "rpmlint",
             "yum-utils",
-            stdout=build._io.output.stream,
+            stdout=build.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -252,7 +252,7 @@ class BaseRPMTarget(targets.FHSTarget, targets.LinuxDistroTarget):
             "-y",
             spec,
             cwd=str(build.get_spec_root(relative_to="fsroot")),
-            stdout=build._io.output.stream,
+            stdout=build.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -287,7 +287,7 @@ class RHEL9OrNewerTarget(RHEL7OrNewerTarget):
             "install",
             "-y",
             "systemd-rpm-macros",  # for %_unitdir
-            stdout=build._io.output.stream,
+            stdout=build.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -306,7 +306,7 @@ class FedoraTarget(RHEL7OrNewerTarget):
             "-y",
             spec,
             cwd=str(build.get_spec_root(relative_to="fsroot")),
-            stdout=build._io.output.stream,
+            stdout=build.stream,
             stderr=subprocess.STDOUT,
         )
 

--- a/metapkg/targets/rpm/build.py
+++ b/metapkg/targets/rpm/build.py
@@ -696,7 +696,7 @@ class Build(targets.Build):
             "rpmbuild",
             *args,
             cwd=str(self.get_spec_root(relative_to="fsroot")),
-            stdout=self._io.output.stream,
+            stdout=self.stream,
             stderr=subprocess.STDOUT,
         )
 
@@ -705,7 +705,7 @@ class Build(targets.Build):
             "-i",
             f"{self._root_pkg.name_slot}.spec",
             cwd=str(self.get_spec_root(relative_to="fsroot")),
-            stdout=self._io.output.stream,
+            stdout=self.stream,
             stderr=subprocess.STDOUT,
         )
 

--- a/setup.py
+++ b/setup.py
@@ -20,10 +20,7 @@ setup(
         "build~=1.2.1",
         "distro~=1.9.0",
         "requests~=2.31.0",
-        "poetry~=1.2.0",
-        # Poetry <1.5.0 is not compatible with setuptools>=70.2.0
-        # See https://github.com/pypa/setuptools/pull/4434
-        "setuptools<70.2.0",
+        "poetry~=1.8.3",
         "distlib~=0.3.8",
         'python-magic~=0.4.26; platform_system=="Linux" or (platform_machine!="x86_64" and platform_machine!="AMD64")',
         'python-magic-bin~=0.4.14; platform_system!="Linux" and platform_machine!="arm64"',

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "build~=1.2.1",
         "distro~=1.9.0",
         "requests~=2.31.0",
-        "poetry~=1.8.3",
+        "poetry~=2.1.2",
         "distlib~=0.3.8",
         'python-magic~=0.4.26; platform_system=="Linux" or (platform_machine!="x86_64" and platform_machine!="AMD64")',
         'python-magic-bin~=0.4.14; platform_system!="Linux" and platform_machine!="arm64"',


### PR DESCRIPTION
Locally, it runs; I'll test it in CI before marking it as ready for review.

It looks like the `maturin` issue wasn't related to Poetry after all. We installed build dependencies ourselves, but we didn't add the `bin` directory to the `PATH` environment variable. Fixed in #39 in a way that the package maintainer could specify what tools it needs, metapkg would collect all executable directories and append to `PATH` variable.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/10354757319)