### PR TITLE
Improve handling of package dependencies, support CMake and Meson

### DIFF
--- a/metapkg/commands/build.py
+++ b/metapkg/commands/build.py
@@ -101,14 +101,6 @@ class Build(base.Command):
         if tags:
             root_pkg.set_metadata_tags(tags)
 
-        sources = root_pkg.get_sources()
-
-        if len(sources) != 1:
-            self.io.write_error_line(
-                "Only single-source packages are supported"
-            )
-            return 1
-
         env = poetry_env.SystemEnv(pathlib.Path(sys.executable))
         packages, build_pkgs = self._resolve_deps(env, target, root_pkg, [])
 

--- a/metapkg/packages/__init__.py
+++ b/metapkg/packages/__init__.py
@@ -1,15 +1,21 @@
 # flake8: noqa
 
 from .base import (
+    Args,
     BasePackage,
     BundledPackage,
     PrePackagedPackage,
+    BuildSystemMakePackage,
     BundledCPackage,
+    BundledCAutoconfPackage,
+    BundledCMakePackage,
     BundledCMesonPackage,
+    CMakeTargetBuildSystem,
     PackageFileLayout,
     MetaPackage,
     NormalizedName,
     canonicalize_name,
+    get_bundled_pkg,
     pep440_to_semver,
     semver_pre_tag,
 )
@@ -19,21 +25,27 @@ from .rust import BundledRustPackage, BundledAdHocRustPackage
 
 
 __all__ = (
+    "Args",
     "BasePackage",
     "BundledPackage",
     "PrePackagedPackage",
     "PackageFileLayout",
     "MetaPackage",
     "PythonPackage",
+    "BuildSystemMakePackage",
     "BundledCPackage",
+    "BundledCAutoconfPackage",
+    "BundledCMakePackage",
     "BundledCMesonPackage",
     "BundledGoPackage",
     "BundledAdHocGoPackage",
     "BundledPythonPackage",
     "BundledRustPackage",
     "BundledAdHocRustPackage",
+    "CMakeTargetBuildSystem",
     "NormalizedName",
     "canonicalize_name",
+    "get_bundled_pkg",
     "pep440_to_semver",
     "semver_pre_tag",
 )

--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -250,7 +250,19 @@ class BasePackage(poetry_pkg.Package):
         build: targets.Build,
         aspect: targets.InstallAspect,
     ) -> pathlib.Path | None:
-        return None
+        pkg_config = self.get_pkg_config_meta()
+        if aspect == "lib" and not pkg_config.provides_shlibs:
+            return None
+        elif aspect == "include" and not pkg_config.provides_c_headers:
+            return None
+        elif (
+            aspect == "bin"
+            and not pkg_config.provides_build_tools
+            and not pkg_config.pkg_config_script
+        ):
+            return None
+        else:
+            return build.get_install_path(self, aspect)
 
     def get_shlibs(self, build: targets.Build) -> list[str]:
         return []
@@ -703,25 +715,6 @@ class BundledPackage(BasePackage):
             return self.resolved_sources
         else:
             return self._get_sources(version=self.source_version)
-
-    def get_install_path(
-        self,
-        build: targets.Build,
-        aspect: targets.InstallAspect,
-    ) -> pathlib.Path | None:
-        pkg_config = self.get_pkg_config_meta()
-        if aspect == "lib" and not pkg_config.provides_shlibs:
-            return None
-        elif aspect == "include" and not pkg_config.provides_c_headers:
-            return None
-        elif (
-            aspect == "bin"
-            and not pkg_config.provides_build_tools
-            and not pkg_config.pkg_config_script
-        ):
-            return None
-        else:
-            return build.get_install_path(self, aspect)
 
     def get_patches(
         self,

--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -414,10 +414,12 @@ class BasePythonPackage(base.BasePackage):
             if ldflags:
                 build.sh_append_quoted_ldflags(env, ldflags)
 
-            paths = build.sh_get_command_paths(self.get_dep_commands(), self)
+            bin_paths = build.sh_get_bundled_pkgs_bin_paths(
+                build_deps, relative_to="pkgsource"
+            )
 
-            if paths:
-                build.sh_prepend_paths(env, "PATH", paths)
+            if bin_paths:
+                build.sh_prepend_quoted_paths(env, "PATH", bin_paths)
 
             binary = True
 

--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -317,12 +317,13 @@ def is_build_system_bootstrap_package(
 class BasePythonPackage(base.BasePackage):
     source: af_sources.BaseSource
 
-    def get_configure_script(self, build: targets.Build) -> str:
-        return ""
-
     def sh_get_build_wheel_env(
-        self, build: targets.Build, *, site_packages_var: str
-    ) -> dict[str, str]:
+        self,
+        build: targets.Build,
+        *,
+        site_packages: str,
+        wd: str,
+    ) -> base.Args:
         return {}
 
     def get_build_script(self, build: targets.Build) -> str:
@@ -333,13 +334,13 @@ class BasePythonPackage(base.BasePackage):
         build_python = build.sh_get_command("python")
         dest = build.get_temp_root(
             relative_to="pkgbuild"
-        ) / build.get_full_install_prefix().relative_to("/")
+        ) / build.get_rel_install_prefix(self)
 
         sitescript = f'import site; print(site.getsitepackages(["{dest}"])[0])'
 
         src_dest = build.get_temp_root(
             relative_to="pkgsource"
-        ) / build.get_full_install_prefix().relative_to("/")
+        ) / build.get_rel_install_prefix(self)
 
         src_sitescript = (
             f'import site; print(site.getsitepackages(["{src_dest}"])[0])'
@@ -364,10 +365,12 @@ class BasePythonPackage(base.BasePackage):
             }
         )
 
-        build_deps = build.get_bundled_build_reqs(self)
+        build_deps = build.get_build_reqs(self)
 
         if is_build_system_bootstrap_package(pkgname):
-            tarball = build.get_tarball(self, relative_to="pkgsource")
+            tarballs = build.get_tarballs(self, relative_to="pkgsource")
+            assert len(tarballs) == 1, "expected exactly one tarball"
+            _, tarball = tarballs[0]
             build_command = f'cp "{tarball}" ${{_wheeldir}}/{pkgname}-{self.version}.tar.gz'
             binary = False
         else:
@@ -389,11 +392,13 @@ class BasePythonPackage(base.BasePackage):
             )
             env.update(
                 self.sh_get_build_wheel_env(
-                    build, site_packages_var="${_sitepkg_from_src}"
+                    build,
+                    site_packages="${_sitepkg_from_src}",
+                    wd="${_wd}",
                 )
             )
 
-            cflags = build.sh_get_bundled_shlibs_cflags(
+            cflags = build.sh_get_bundled_pkgs_cflags(
                 build_deps,
                 relative_to="pkgsource",
             )
@@ -401,7 +406,7 @@ class BasePythonPackage(base.BasePackage):
             if cflags:
                 build.sh_append_quoted_flags(env, "CFLAGS", cflags)
 
-            ldflags = build.sh_get_bundled_shlibs_ldflags(
+            ldflags = build.sh_get_bundled_pkgs_ldflags(
                 build_deps,
                 relative_to="pkgsource",
             )
@@ -412,13 +417,12 @@ class BasePythonPackage(base.BasePackage):
             paths = build.sh_get_command_paths(self.get_dep_commands(), self)
 
             if paths:
-                build.sh_append_paths(env, paths)
+                build.sh_prepend_paths(env, "PATH", paths)
 
             binary = True
 
-        all_build_deps = build.get_bundled_build_reqs(self, recursive=True)
+        env |= self.get_build_env(build, wd="${_wd}")
         env_str = build.sh_format_command("env", env, force_args_eq=True)
-        env_str += " " + " ".join(build.get_ld_env(all_build_deps, "${_wd}"))
 
         build_cmds = [build_command]
         build_cmds.extend(self.get_extra_python_build_commands(build))
@@ -461,7 +465,7 @@ class BasePythonPackage(base.BasePackage):
         common_script = super().get_build_install_script(build)
 
         python = build.sh_get_command("python", package=self)
-        root = build.get_install_dir(self, relative_to="pkgbuild")
+        root = build.get_build_install_dir(self, relative_to="pkgbuild")
         wheeldir_script = 'import pathlib; print(pathlib.Path(".").resolve())'
 
         pkgname = getattr(self, "dist_name", None)
@@ -504,8 +508,8 @@ class BasePythonPackage(base.BasePackage):
     def get_install_list_script(self, build: targets.Build) -> str:
         common_script = super().get_install_list_script(build)
 
-        prefix = build.get_full_install_prefix()
-        dest = build.get_install_dir(self, relative_to="pkgbuild")
+        prefix = build.get_install_prefix(self)
+        dest = build.get_build_install_dir(self, relative_to="pkgbuild")
 
         pkgname = getattr(self, "dist_name", None)
         if pkgname is None:
@@ -591,12 +595,16 @@ class BundledPythonPackage(BasePythonPackage, base.BundledPackage):
         revision: str | None = None,
         is_release: bool = False,
         target: targets.Target,
+        requires: list[poetry_dep.Dependency] | None = None,
     ) -> BundledPythonPackage_T:
         repo = cls.resolve_vcs_repo(io, version)
         repo_dir = repo.work_tree
         dist = get_dist(repo_dir)
 
-        requires = []
+        if requires is not None:
+            requires = list(requires)
+        else:
+            requires = []
         for req in dist.metadata.run_requires:
             dep = python_dependency_from_pep_508(req)
             requires.append(dep)
@@ -663,13 +671,17 @@ class FlitCore(PythonPackage):
 
 class Tomli(PythonPackage):
     def sh_get_build_wheel_env(
-        self, build: targets.Build, *, site_packages_var: str
-    ) -> dict[str, str]:
-        env = dict(
-            super().sh_get_build_wheel_env(
-                build, site_packages_var=site_packages_var
-            )
-        )
+        self,
+        build: targets.Build,
+        *,
+        site_packages: str,
+        wd: str,
+    ) -> mpkg.Args:
         sdir = build.get_source_dir(self, relative_to="pkgbuild")
-        env["EXTRA_PYTHONPATH"] = str(sdir)
-        return env
+        return super().sh_get_build_wheel_env(
+            build,
+            site_packages=site_packages,
+            wd=wd,
+        ) | {
+            "EXTRA_PYTHONPATH": sdir,
+        }

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -44,7 +44,7 @@ def _DependencyCache_search_for(
         dependency.source_subdirectory,
     )
 
-    packages = self.cache.get(key)
+    packages = self.cache.get(key)  # type: ignore
     if packages is None:
         packages = self.provider.search_for(dependency)
     else:
@@ -54,7 +54,7 @@ def _DependencyCache_search_for(
             if dependency.constraint.allows(p.package.version)
         ]
 
-    self.cache[key] = packages
+    self.cache[key] = packages  # type: ignore
 
     return packages
 

--- a/metapkg/packages/repository.py
+++ b/metapkg/packages/repository.py
@@ -21,6 +21,7 @@ from poetry.core.semver import version as poetry_version
 from poetry.packages import dependency_package as poetry_deppkg
 from poetry.core.packages import package as poetry_pkg
 from poetry.mixology import incompatibility as poetry_incompat
+from poetry.mixology import version_solver as poetry_versolver
 from poetry.puzzle import provider as poetry_provider
 from poetry.vcs import git as poetry_git
 
@@ -28,6 +29,37 @@ from . import sources as mpkg_sources
 
 if TYPE_CHECKING:
     from cleo.io import io as cleo_io
+
+
+def _DependencyCache_search_for(
+    self: poetry_versolver.DependencyCache,
+    dependency: poetry_dep.Dependency,
+) -> list[poetry_deppkg.DependencyPackage]:
+    key = (
+        dependency.complete_name,
+        dependency.pretty_constraint,
+        dependency.source_type,
+        dependency.source_url,
+        dependency.source_reference,
+        dependency.source_subdirectory,
+    )
+
+    packages = self.cache.get(key)
+    if packages is None:
+        packages = self.provider.search_for(dependency)
+    else:
+        packages = [
+            p
+            for p in packages
+            if dependency.constraint.allows(p.package.version)
+        ]
+
+    self.cache[key] = packages
+
+    return packages
+
+
+poetry_versolver.DependencyCache._search_for = _DependencyCache_search_for  # type: ignore
 
 
 class Pool(poetry_pool.Pool):

--- a/metapkg/packages/rust.py
+++ b/metapkg/packages/rust.py
@@ -6,6 +6,7 @@ from typing import (
 import pathlib
 import textwrap
 
+from poetry.core.packages import dependency as poetry_dep
 from poetry.core.semver import version as poetry_version
 from poetry.core.version import pep440 as poetry_pep440
 
@@ -63,9 +64,6 @@ class BundledRustPackage(base.BundledPackage):
 
         return version
 
-    def get_configure_script(self, build: targets.Build) -> str:
-        return ""
-
     def get_build_script(self, build: targets.Build) -> str:
         return ""
 
@@ -75,9 +73,9 @@ class BundledRustPackage(base.BundledPackage):
         sed = build.sh_get_command("sed")
         installdest = build.get_temp_dir(self, relative_to="pkgbuild")
         src = build.get_source_dir(self, relative_to="pkgbuild")
-        bindir = build.get_install_path("systembin").relative_to("/")
+        bindir = build.get_bundle_install_path("systembin").relative_to("/")
         install_bindir = (
-            build.get_install_dir(self, relative_to="pkgbuild") / bindir
+            build.get_build_install_dir(self, relative_to="pkgbuild") / bindir
         )
         env = build.sh_append_global_flags({})
         env["RUST_BACKTRACE"] = "1"
@@ -115,6 +113,7 @@ class BundledAdHocRustPackage(BundledRustPackage):
         revision: str | None = None,
         is_release: bool = False,
         target: targets.Target,
+        requires: list[poetry_dep.Dependency] | None = None,
     ) -> BundledAdHocRustPackage:
         sources = cls._get_sources(version)
 
@@ -147,4 +146,5 @@ class BundledAdHocRustPackage(BundledRustPackage):
             pretty_version=pretty_version,
             source_version=version,
             resolved_sources=sources,
+            requires=requires,
         )

--- a/metapkg/packages/utils.py
+++ b/metapkg/packages/utils.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import *
 
 import packaging.utils
 

--- a/metapkg/targets/__init__.py
+++ b/metapkg/targets/__init__.py
@@ -6,6 +6,7 @@ import platform
 from .base import (
     Build,
     BuildRequest,
+    InstallAspect,
     Target,
     Location,
     LinuxTarget,
@@ -26,6 +27,7 @@ __all__ = (
     "BuildRequest",
     "EnsureDirAction",
     "AddUserAction",
+    "InstallAspect",
     "Location",
     "Target",
     "LinuxTarget",

--- a/metapkg/targets/_helpers/copy-tree.py
+++ b/metapkg/targets/_helpers/copy-tree.py
@@ -1,6 +1,12 @@
 #!/usr/bin/env python3
 from __future__ import annotations
-from typing import *
+from typing import (
+    Collection,
+    Iterable,
+    Iterator,
+    Optional,
+    NoReturn,
+)
 
 import argparse
 import logging
@@ -238,9 +244,9 @@ def warn_about_excluded_files(
     maybe_warn()
 
 
-def add_missing_directory_entries(files: Iterable[str]) -> List[str]:
-    dirs: Set[pathlib.Path] = {pathlib.Path(".")}
-    result: Set[str] = set()
+def add_missing_directory_entries(files: Iterable[str]) -> list[str]:
+    dirs: set[pathlib.Path] = {pathlib.Path(".")}
+    result: set[str] = set()
     for file in files:
         if file.endswith("/"):
             file = file[:-1]

--- a/metapkg/targets/base.py
+++ b/metapkg/targets/base.py
@@ -1913,22 +1913,22 @@ class Build:
         else:
             return None
 
-    def sh_get_command_paths(
+    def sh_get_bundled_pkgs_bin_paths(
         self,
-        commands: Iterable[str],
-        pkg: mpkg_base.BasePackage,
+        deps: Iterable[mpkg_base.BasePackage],
+        relative_to: Location = "pkgbuild",
     ) -> list[str]:
-        paths = set()
-        src_root = self.get_source_abspath()
-        for cmd in commands:
-            cmd_txt = self.sh_get_command(
-                cmd, package=pkg, relative_to="sourceroot"
-            )
-            if os.path.sep not in cmd_txt:
-                # Skip global commands
-                continue
-            paths.add(src_root / pathlib.Path(cmd_txt).parent)
-        return [str(p) for p in paths]
+        paths = []
+
+        for pkg in deps:
+            if self.is_bundled(pkg):
+                path = self.sh_get_bundled_pkg_bin_path(
+                    pkg, relative_to=relative_to
+                )
+                if path is not None:
+                    paths.append(path)
+
+        return paths
 
     def sh_append_global_flags(
         self,

--- a/metapkg/targets/deb/__init__.py
+++ b/metapkg/targets/deb/__init__.py
@@ -40,6 +40,17 @@ PACKAGE_MAP = {
     "ncurses": "ncurses-bin",
     "libffi-dev": "libffi-dev",
     "openssl-dev": "libssl-dev",
+    "libexpat": "libexpat?",
+    "libexpat-dev": "libexpat?-dev",
+    "libgeos": "libgeos-c1v?",
+    "libgeotiff": "libgeotiff?",
+    "libjson-c": "libjson-c?",
+    "libsqlite3": "libsqlite3-?",
+    "libtiff": "libtiff?",
+    "libprotobuf-c": "libprotobuf-c?",
+    "libgdal": "libgdal??",
+    "libproj": "libproj??",
+    "protoc-c": "protobuf-c-compiler",
 }
 
 
@@ -180,7 +191,7 @@ class DebRepository(poetry_repo.Repository):
                 if not seen_name:
                     if not line.endswith(":"):
                         raise RuntimeError(
-                            "cannot parse apt-cache policy output"
+                            f"cannot parse apt-cache policy output:\n{output}"
                         )
                     meta["name"] = line[:-1]
                     seen_name = True
@@ -217,12 +228,13 @@ class DebRepository(poetry_repo.Repository):
 
                     last_indent = indent
                 else:
-                    raise RuntimeError("cannot parse apt-cache policy output")
-
-            meta["versions"] = versions
-            if versions:
+                    raise RuntimeError(
+                        f"cannot parse apt-cache policy output:\n{output}"
+                    )
+            else:
                 vno += 1
 
+            meta["versions"] = versions
             lines = lines[vno:]
             metas.append(meta)
 

--- a/metapkg/targets/generic/__init__.py
+++ b/metapkg/targets/generic/__init__.py
@@ -68,42 +68,48 @@ class GenericOSRepository(poetry_repo.Repository):
 class GenericTarget(targets.FHSTarget):
     @property
     def name(self) -> str:
-        return f"Generic POSIX"
+        return "Generic POSIX"
 
     def get_package_repository(self) -> GenericOSRepository:
         return GenericOSRepository("generic")
 
-    def get_install_root(self, build: targets.Build) -> pathlib.Path:
+    def get_bundle_install_root(self, build: targets.Build) -> pathlib.Path:
         return pathlib.Path("/opt")
 
-    def get_install_prefix(self, build: targets.Build) -> pathlib.Path:
-        return pathlib.Path(build.root_package.name_slot)
+    def get_bundle_install_subdir(self, build: targets.Build) -> pathlib.Path:
+        return build.root_package.get_root_install_subdir(build)
 
     def get_install_path(
-        self, build: targets.Build, aspect: str
+        self,
+        build: targets.Build,
+        root: pathlib.Path,
+        root_subdir: pathlib.Path,
+        prefix: pathlib.Path,
+        aspect: targets.InstallAspect,
     ) -> pathlib.Path:
-        root = self.get_install_root(build)
-        prefix = self.get_install_prefix(build)
-
         if aspect == "sysconf":
             return root / "etc"
         elif aspect == "userconf":
             return pathlib.Path("$HOME") / ".config"
         elif aspect == "data":
-            return root / prefix / "data"
+            return prefix / "share"
         elif aspect == "legal":
-            return root / prefix / "licenses"
+            return prefix / "licenses"
+        elif aspect == "doc":
+            return prefix / "doc" / root_subdir
+        elif aspect == "man":
+            return prefix / "man"
         elif aspect == "bin":
-            return root / prefix / "bin"
+            return prefix / "bin"
         elif aspect == "systembin":
             if root == pathlib.Path("/"):
                 return root / "usr" / "bin"
             else:
                 return root / "bin"
         elif aspect == "lib":
-            return root / prefix / "lib"
+            return prefix / "lib"
         elif aspect == "include":
-            return root / prefix / "include"
+            return prefix / "include"
         elif aspect == "localstate":
             return root / "var"
         elif aspect == "runstate":

--- a/metapkg/targets/linux/__init__.py
+++ b/metapkg/targets/linux/__init__.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-from typing import *
 
 import distro
 

--- a/metapkg/targets/linux/build.py
+++ b/metapkg/targets/linux/build.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import os
 import os.path
 import pathlib
-import platform
 
 from metapkg import tools
 from metapkg.targets import generic
@@ -31,7 +30,7 @@ class GenericLinuxBuild(generic.Build):
     def _fixup_rpath(
         self, image_root: pathlib.Path, binary_relpath: pathlib.Path
     ) -> None:
-        inst_prefix = self.get_full_install_prefix()
+        inst_prefix = self.get_bundle_install_prefix()
         full_path = image_root / binary_relpath
         inst_path = pathlib.Path("/") / binary_relpath
         rpath_record = tools.cmd(

--- a/metapkg/targets/rpm/__init__.py
+++ b/metapkg/targets/rpm/__init__.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
-from typing import *
+from typing import (
+    TYPE_CHECKING,
+    Any,
+)
 
 import functools
 import pathlib
@@ -34,6 +37,26 @@ PACKAGE_MAP = {
     "openssl-dev": "openssl-devel",
     "libffi-dev": "libffi-devel",
     "libb2-dev": "libb2-devel",
+    "libpcre2": "pcre2",
+    "libpcre2-dev": "pcre2-devel",
+    "libxml2-dev": "libxml2-devel",
+    "libexpat": "expat",
+    "libexpat-dev": "expat-devel",
+    "libgeos": "geos",
+    "libgeos-dev": "geos-devel",
+    "libgeotiff-dev": "libgeotiff-devel",
+    "libjson-c": "json-c",
+    "libjson-c-dev": "json-c-devel",
+    "libsqlite3": "sqlite-libs",
+    "libsqlite3-dev": "sqlite-devel",
+    "libtiff-dev": "libtiff-devel",
+    "libprotobuf-c": "protobuf-c",
+    "libprotobuf-c-dev": "protobuf-c-devel",
+    "libgdal": "gdal",
+    "libgdal-dev": "gdal-devel",
+    "libproj": "proj",
+    "libproj-dev": "proj-devel",
+    "protoc-c": "protobuf-c-compiler",
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [tool.black]
 line-length = 79
-target-version = ["py39"]
+target-version = ["py312"]
 
 [tool.mypy]
 files = "metapkg"
-python_version = "3.9"
+python_version = "3.12"
 follow_imports = "normal"
 ignore_missing_imports = true
 show_error_codes = true

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     ],
     extras_require={
         "test": [
+            "typing-extensions~=4.0",
             "types-requests~=2.31.0.2",
         ]
     },


### PR DESCRIPTION
This is a fairly large-looking refactor aimed to replace manual
dependency configuration in package classes with automatic discovery
using pkg-config or CMake-provided package configs.  Most packages ship
those and setting `PKG_CONFIG_PATH` and `CMAKE_PREFIX_PATH` is far more
robust than fiddling with `*FLAGS` directly.

This also adds full support for the CMake and Meson build systems and
makes lots of small changes required to do so in a clean fashion and
also to reduce boilerplate in package classes.

Specifically:

- overloading `get_configure_script` is no longer necessary for packages
  using supported build systems, `get_configure_args` and
  `get_configure_env` should be overloaded instead, returning a clean
  dictionary of flags instead;

- related to above, calling `configure_dependency` directly is not
  required anymore, dependencies are auto-configured based on their
  own build system declaration;

- `get_build_script` and `get_build_install_script` overloads should not
  call `make` (or whatever build system equivalent) and should instead
  call `get_build_command()` and `get_build_install_command()`
  correspondingly which take care of command formatting and injection of
  environment and global arguments.

Additionally, the root package can now control the overall layout of the
package bundle:

- `get_dep_install_subdir` may be overloaded to put all dependencies under
  a specified root, which is useful for packaging plugins and extensions
  that have dynamic library dependencies which should ideally be isolated
  with from similar dependencies of the host program;

- `get_root_install_subdir` may be overloaded to customize the name of
  the common parent directory in the installation prefix, e.g in
  `/opt/<subdir>` or `/usr/lib/<host-triple>/<subdir>`.

Other misc improvements and fixes:

- add support for building with Ninja;
- allow packages to have multiple source tarballs;
- use `{mandir}` and `{docdir}` install patterns instead of hardcoded
  `{datadir}`-based paths;
