### PR TITLE
Fix relative_to="pkgsource" in generic build

### DIFF
--- a/metapkg/packages/python.py
+++ b/metapkg/packages/python.py
@@ -399,6 +399,7 @@ class BasePythonPackage(base.BasePackage):
             cflags = build.sh_get_bundled_pkgs_cflags(
                 build_deps,
                 relative_to="pkgsource",
+                relative_to_package=self,
             )
 
             if cflags:
@@ -407,13 +408,14 @@ class BasePythonPackage(base.BasePackage):
             ldflags = build.sh_get_bundled_pkgs_ldflags(
                 build_deps,
                 relative_to="pkgsource",
+                relative_to_package=self,
             )
 
             if ldflags:
                 build.sh_append_quoted_ldflags(env, ldflags)
 
             bin_paths = build.sh_get_bundled_pkgs_bin_paths(
-                build_deps, relative_to="pkgsource"
+                build_deps, relative_to="pkgsource", relative_to_package=self
             )
 
             if bin_paths:

--- a/metapkg/targets/base.py
+++ b/metapkg/targets/base.py
@@ -982,6 +982,7 @@ class Build:
         package: mpkg_base.BasePackage,
         *,
         relative_to: Location = "sourceroot",
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> pathlib.Path:
         """Return the path at which *package* is installed in the buildroot.
 
@@ -1770,12 +1771,17 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> str | None:
         if wd is None:
             wd = "$(pwd -P)"
         assert self.is_bundled(pkg)
 
-        root_path = self.get_build_install_dir(pkg, relative_to=relative_to)
+        root_path = self.get_build_install_dir(
+            pkg,
+            relative_to=relative_to,
+            relative_to_package=relative_to_package,
+        )
         shlib_path = pkg.get_install_path(self, "lib")
         if shlib_path is not None:
             lib_path = root_path / shlib_path.relative_to("/")
@@ -1788,8 +1794,11 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> str:
-        path = self.sh_get_bundled_pkg_lib_path(pkg, relative_to, wd)
+        path = self.sh_get_bundled_pkg_lib_path(
+            pkg, relative_to, wd, relative_to_package
+        )
         if path is None:
             raise AssertionError(f"{pkg.name} does not define a DSO lib path")
         return path
@@ -1799,6 +1808,7 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> list[str]:
         flags = []
 
@@ -1808,6 +1818,7 @@ class Build:
             pkg,
             relative_to=relative_to,
             wd=wd,
+            relative_to_package=relative_to_package,
         )
         if lib_path is not None:
             # link-time
@@ -1831,6 +1842,7 @@ class Build:
         deps: Iterable[mpkg_base.BasePackage],
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> list[str]:
         flags = []
 
@@ -1838,7 +1850,10 @@ class Build:
             if self.is_bundled(pkg):
                 flags.extend(
                     self.sh_get_bundled_pkg_ldflags(
-                        pkg, relative_to=relative_to, wd=wd
+                        pkg,
+                        relative_to=relative_to,
+                        wd=wd,
+                        relative_to_package=relative_to_package,
                     )
                 )
 
@@ -1849,6 +1864,7 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> str | None:
         assert self.is_bundled(pkg)
 
@@ -1858,7 +1874,9 @@ class Build:
         rel_inc_path = pkg.get_install_path(self, "include")
         if rel_inc_path is not None:
             root_path = self.get_build_install_dir(
-                pkg, relative_to=relative_to
+                pkg,
+                relative_to=relative_to,
+                relative_to_package=relative_to_package,
             )
             inc_path = root_path / rel_inc_path.relative_to("/")
             return f"{wd}/{shlex.quote(str(inc_path))}"
@@ -1870,8 +1888,11 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> str:
-        path = self.sh_get_bundled_pkg_include_path(pkg, relative_to, wd)
+        path = self.sh_get_bundled_pkg_include_path(
+            pkg, relative_to, wd, relative_to_package
+        )
         if path is None:
             raise AssertionError(
                 f"{pkg.name} does not define a header include path"
@@ -1883,8 +1904,11 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> list[str]:
-        path = self.sh_get_bundled_pkg_include_path(pkg, relative_to, wd=wd)
+        path = self.sh_get_bundled_pkg_include_path(
+            pkg, relative_to, wd=wd, relative_to_package=relative_to_package
+        )
         if path is not None:
             return [f"-I{path}"]
         else:
@@ -1894,6 +1918,7 @@ class Build:
         self,
         deps: Iterable[mpkg_base.BasePackage],
         relative_to: Location = "pkgbuild",
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> list[str]:
         flags = []
 
@@ -1901,7 +1926,9 @@ class Build:
             if self.is_bundled(pkg):
                 flags.extend(
                     self.sh_get_bundled_pkg_cflags(
-                        pkg, relative_to=relative_to
+                        pkg,
+                        relative_to=relative_to,
+                        relative_to_package=relative_to_package,
                     )
                 )
 
@@ -1912,6 +1939,7 @@ class Build:
         pkg: mpkg_base.BasePackage,
         relative_to: Location = "pkgbuild",
         wd: str | None = None,
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> str | None:
         assert self.is_bundled(pkg)
 
@@ -1921,7 +1949,9 @@ class Build:
         rel_bin_path = pkg.get_install_path(self, "bin")
         if rel_bin_path:
             root_path = self.get_build_install_dir(
-                pkg, relative_to=relative_to
+                pkg,
+                relative_to=relative_to,
+                relative_to_package=relative_to_package,
             )
             bin_path = root_path / rel_bin_path.relative_to("/")
             return f"{wd}/{shlex.quote(str(bin_path))}"
@@ -1932,13 +1962,16 @@ class Build:
         self,
         deps: Iterable[mpkg_base.BasePackage],
         relative_to: Location = "pkgbuild",
+        relative_to_package: mpkg_base.BasePackage | None = None,
     ) -> list[str]:
         paths = []
 
         for pkg in deps:
             if self.is_bundled(pkg):
                 path = self.sh_get_bundled_pkg_bin_path(
-                    pkg, relative_to=relative_to
+                    pkg,
+                    relative_to=relative_to,
+                    relative_to_package=relative_to_package,
                 )
                 if path is not None:
                     paths.append(path)

--- a/metapkg/targets/deb/build.py
+++ b/metapkg/targets/deb/build.py
@@ -152,9 +152,12 @@ class Build(targets.Build):
         package: packages.BasePackage,
         *,
         relative_to: targets.Location = "sourceroot",
+        relative_to_package: packages.BasePackage | None = None,
     ) -> pathlib.Path:
         return self.get_dir(
-            self._installroot / package.name, relative_to=relative_to
+            self._installroot / package.name,
+            relative_to=relative_to,
+            package=relative_to_package,
         )
 
     def _get_tarball_tpl(self, package: packages.BasePackage) -> str:

--- a/metapkg/targets/generic/build.py
+++ b/metapkg/targets/generic/build.py
@@ -192,11 +192,12 @@ class Build(targets.Build):
         package: packages.BasePackage,
         *,
         relative_to: targets.Location = "sourceroot",
+        relative_to_package: packages.BasePackage | None = None,
     ) -> pathlib.Path:
         return self.get_dir(
             self._installroot / package.name,
             relative_to=relative_to,
-            package=package,
+            package=relative_to_package or package,
         )
 
     def _get_tarball_tpl(self, package: packages.BasePackage) -> str:

--- a/metapkg/targets/rpm/build.py
+++ b/metapkg/targets/rpm/build.py
@@ -155,9 +155,12 @@ class Build(targets.Build):
         package: mpkg.BasePackage,
         *,
         relative_to: targets.Location = "sourceroot",
+        relative_to_package: mpkg.BasePackage | None = None,
     ) -> pathlib.Path:
         return self.get_dir(
-            self._installroot / package.name, relative_to=relative_to
+            self._installroot / package.name,
+            relative_to=relative_to,
+            package=relative_to_package,
         )
 
     def _get_tarball_tpl(self, package: mpkg.BasePackage) -> str:

--- a/metapkg/targets/rpm/build.py
+++ b/metapkg/targets/rpm/build.py
@@ -468,7 +468,7 @@ class Build(targets.Build):
 
     def _get_package_unpack_script(self, pkg: mpkg.BasePackage) -> str:
         tarball_root = self.get_tarball_root(relative_to="pkgbuild")
-        tarballs = self._tarballs[pkg]
+        tarballs = self._tarballs.get(pkg, [])
         script = []
 
         for src, tarball_path in tarballs:


### PR DESCRIPTION
include dir seems wrong in https://github.com/edgedb/edgedb/actions/runs/11944890842/job/33296624198:

```
2024-11-21T02:03:55.4341953Z   building 'edb.pgsql.parser.parser' extension
2024-11-21T02:03:55.4342598Z   creating build/temp.linux-x86_64-cpython-312/edb/pgsql
2024-11-21T02:03:55.4343137Z   creating build/temp.linux-x86_64-cpython-312/edb/pgsql/parser
2024-11-21T02:03:55.4352051Z   gcc -pthread -fno-strict-overflow -DNDEBUG -g -O3 -Wall -fno-semantic-interposition -g -O2 -D_FORTIFY_SOURCE=2 -fstack-protector-strong -Wdate-time -Wformat -Werror=format-security -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/../../../_artifacts/install/postgresql-edgedb/opt/edgedb-server-6-dev8997/include -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/../../../_artifacts/install/python-edgedb/opt/edgedb-server-6-dev8997/include -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/../../../_artifacts/install/pgext-pgvector/opt/edgedb-server-6-dev8997/include -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/../../../_artifacts/install/libprotobuf-c/opt/edgedb-server-6-dev8997/include -fPIC -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/edb/server/pgproto -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/edb/pgsql/parser/libpg_query -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/thirdparty/python-edgedb/Include -I/tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/_artifacts/build/python-edgedb -c edb/pgsql/parser/parser.c -o build/temp.linux-x86_64-cpython-312/edb/pgsql/parser/parser.o -O2 -Wno-error=incompatible-pointer-types -std=c99 -fsigned-char -Wall -Wsign-compare -Wconversion
2024-11-21T02:03:55.4792087Z   In file included from edb/pgsql/parser/parser.c:1280:
2024-11-21T02:03:55.4793457Z   /tmp/metapkg.0to4_k89/edgedb-server-6-dev8997/edgedb-server/edgedb-server/edb/pgsql/parser/libpg_query/protobuf/pg_query.pb-c.h:7:10: fatal error: protobuf-c/protobuf-c.h: No such file or directory
2024-11-21T02:03:55.4794562Z       7 | #include <protobuf-c/protobuf-c.h>
2024-11-21T02:03:55.4795128Z         |          ^~~~~~~~~~~~~~~~~~~~~~~~~
2024-11-21T02:03:55.4795436Z   compilation terminated.
2024-11-21T02:03:55.4803886Z   error: command '/opt/rh/devtoolset-11/root/usr/bin/gcc' failed with exit code 1
2024-11-21T02:03:55.5256802Z   error: subprocess-exited-with-error
2024-11-21T02:03:55.5257231Z   
2024-11-21T02:03:55.5261952Z   × Building wheel for gel-server (pyproject.toml) did not run successfully.
2024-11-21T02:03:55.5266576Z   │ exit code: 1
2024-11-21T02:03:55.5270237Z   ╰─> See above for output.
```

where the relevant include option resolves to:

```
-I/tmp/metapkg.0to4_k89/_artifacts/install/libprotobuf-c/opt/edgedb-server-6-dev8997/include
```

It's missing the `edgedb-server-6-dev8997/` after `/tmp/metapkg.0to4_k89/`.

The problem is using the wrong package when `relative_to="pkgsource"` in the generic build `get_build_install_dir()` for root package dependencies.

[Sample run](https://github.com/edgedb/edgedb/actions/runs/11963760085/job/33354820762)