### PR TITLE
Fix breakage caused by setuptools recent PEP 491 fix

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
         'python-magic~=0.4.26; platform_system=="Linux" or (platform_machine!="x86_64" and platform_machine!="AMD64")',
         'python-magic-bin~=0.4.14; platform_system!="Linux" and platform_machine!="arm64"',
         "wheel>=0.32.3",
+        "setuptools>=75.3.1",
         "setuptools-rust>=0.11.4",
         "tomli>=1.2",
     ],


### PR DESCRIPTION
In https://github.com/pypa/setuptools/pull/4766 the `.dist-info`
directory name was normalized to conform to PEP 491, which broke
content introspection for Python packages.  Adapt some of the
normalization from setuptools to match.
