### PR TITLE
Fix `Package.pretty_version`

### DIFF
--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -123,6 +123,10 @@ class PackageWithPrettyVersion(poetry_pkg.Package):
             else:
                 self._pretty_version = version
 
+    @property
+    def pretty_version(self) -> str:
+        return self._pretty_version
+
 
 class BasePackage(PackageWithPrettyVersion):
     @property


### PR DESCRIPTION
Upstream Poetry removed the distinction between `.pretty_version`
and `.version`, but metapkg relied on it being different as that
is how we keep the original external version of the package
(e.g a PyPI version or a Debian package version).  Restore that
properly.
