### PR TITLE
Fix resolved git date

### DIFF
--- a/metapkg/packages/base.py
+++ b/metapkg/packages/base.py
@@ -753,8 +753,8 @@ class BundledPackage(BasePackage):
             )
 
             git_date = repo.run(
-                "show",
-                "-s",
+                "log",
+                "-1",
                 "--format=%cd",
                 "--date=format-local:%Y%m%d%H",
                 source_version,


### PR DESCRIPTION
If the tag has an attached message, `git show` will output that before the `--format=%cd` even with `-s`, see broken build here:

https://github.com/geldata/gel-cli/actions/runs/14844894394/job/41676359328#step:4:345

```
git show -s --format=%cd --date=format-local:%Y%m%d%H refs/tags/v7.3.0
...
<debug>   1: selecting gel-cli (7.3.0+r202505051952.dtag v7.3.0 ... big message here
```

Fixed by using `git log -1`.

Refs #38