### PR TITLE
Fix when src_ref is full GITHUB_REF with refs/tags/ prefix

### DIFF
--- a/metapkg/tools/git.py
+++ b/metapkg/tools/git.py
@@ -100,7 +100,7 @@ class Git(core_git.Git):
             # The name can be a branch or tag, so we attempt to look it up
             # with ls-remote. If we don't find anything, we assume it's a
             # commit hash.
-            assert '/' not in ref, f"expect commit hash, got: {ref!r}"
+            assert "/" not in ref, f"expect commit hash, got: {ref!r}"
             rev = ref
 
         return rev

--- a/metapkg/tools/git.py
+++ b/metapkg/tools/git.py
@@ -67,10 +67,15 @@ class Git(core_git.Git):
                 sha, name = line.strip().split("\t")
                 sha_map[name] = sha
 
-            # Try peeled tag (refs/tags/<ref>^{})
-            peeled_tag = f"refs/tags/{ref}^{{}}"
-            if peeled_tag in sha_map:
-                rev = sha_map[peeled_tag]
+            if ref in sha_map:
+                # Try if `ref` starts with `ref/*/` already
+                rev = sha_map[ref]
+
+            if rev is None:
+                # Try peeled tag (refs/tags/<ref>^{})
+                peeled_tag = f"refs/tags/{ref}^{{}}"
+                if peeled_tag in sha_map:
+                    rev = sha_map[peeled_tag]
 
             if rev is None:
                 # Try direct tag (refs/tags/<ref>)
@@ -95,6 +100,7 @@ class Git(core_git.Git):
             # The name can be a branch or tag, so we attempt to look it up
             # with ls-remote. If we don't find anything, we assume it's a
             # commit hash.
+            assert '/' not in ref, f"expect commit hash, got: {ref!r}"
             rev = ref
 
         return rev


### PR DESCRIPTION
#46 didn't fix the problem thoroughly, this should do now.

Error fixed here was:

https://github.com/geldata/gel-cli/actions/runs/14844894394/job/41680118680#step:4:483

```
  Invalid PEP 440 version: '7.3.0+r202505052058.d2025050519.grefs/tags.s1c31eaa'
```