### PR TITLE
Omit peeled tags and pseudo-refs when normalizing a remote ref

### DIFF
--- a/metapkg/tools/git.py
+++ b/metapkg/tools/git.py
@@ -273,6 +273,7 @@ class GitClone(Git):
     def _fetch_remote_refs(self) -> dict[str, str]:
         output = self.run(
             "ls-remote",
+            "--refs",
             "origin",
             "refs/tags/**",
             "refs/heads/**",


### PR DESCRIPTION
Neither would be a valid refspec for fetching which is what we are
normalizing for in the first place.
